### PR TITLE
Termination operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,8 +501,8 @@ err('error message').orError((errorResult) => new Error(errorResult))
 // throw new Error('Ooops!')
 err(new Error('Oooops!')).orError()
 
-// INVALID USAGE, unsupported operation
-// throw new Error("Invalid 'orError' usage. Error function was not specified and error type is not Error.")
+// throw new Error('error message'),
+// because the error object casted to string
 err('error message').orError()
 ```
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -120,9 +120,8 @@ export class Err<T, E> {
     if (this.error instanceof Error) {
       throw this.error
     }
-    throw new Error(
-      "Invalid 'orError' usage. Error function was not specified and error type is not Error.",
-    )
+    const message = `${this.error}`
+    throw new Error(message)
   }
 
   _unsafeUnwrap(): T {

--- a/src/result.ts
+++ b/src/result.ts
@@ -47,15 +47,11 @@ export class Ok<T, E> {
   }
 
   or = (defaultValue: T): T => {
-    return this.value === undefined
-           ? defaultValue
-           : this.value
+    return this.value === undefined ? defaultValue : this.value
   }
 
   orGet = (supplier: () => T): T => {
-    return this.value === undefined
-           ? supplier()
-           : this.value
+    return this.value === undefined ? supplier() : this.value
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -119,12 +115,14 @@ export class Err<T, E> {
 
   orError(f?: (e: E) => Error): T {
     if (f) {
-      throw f(this.error);
+      throw f(this.error)
     }
     if (this.error instanceof Error) {
-      throw this.error;
+      throw this.error
     }
-    throw new Error("Invalid 'orError' usage. Error function was not specified and error type is not Error.");
+    throw new Error(
+      "Invalid 'orError' usage. Error function was not specified and error type is not Error.",
+    )
   }
 
   _unsafeUnwrap(): T {

--- a/src/result.ts
+++ b/src/result.ts
@@ -46,6 +46,23 @@ export class Ok<T, E> {
     return ok(this.value)
   }
 
+  or = (defaultValue: T): T => {
+    return this.value === undefined
+           ? defaultValue
+           : this.value
+  }
+
+  orGet = (supplier: () => T): T => {
+    return this.value === undefined
+           ? supplier()
+           : this.value
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  orError(_f?: (e: E) => Error): T {
+    return this.value
+  }
+
   _unsafeUnwrap(): T {
     return this.value
   }
@@ -90,6 +107,24 @@ export class Err<T, E> {
 
   match = <A>(_ok: (t: T) => A, err: (e: E) => A): A => {
     return err(this.error)
+  }
+
+  or = (defaultValue: T): T => {
+    return defaultValue
+  }
+
+  orGet = (supplier: () => T): T => {
+    return supplier()
+  }
+
+  orError(f?: (e: E) => Error): T {
+    if (f) {
+      throw f(this.error);
+    }
+    if (this.error instanceof Error) {
+      throw this.error;
+    }
+    throw new Error("Invalid 'orError' usage. Error function was not specified and error type is not Error.");
   }
 
   _unsafeUnwrap(): T {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -335,21 +335,19 @@ describe('Result.Err', () => {
     })
 
     it('Creates an error and throws it', () => {
-      function throwsError () {
+      function throwsError() {
         err('popa').orError((er) => new Error(er))
       }
 
       expect(throwsError).toThrowError(new Error('popa'))
     })
 
-    it("Invalid 'orError' usage example", () => {
-      function throwsError () {
+    it("Cast to string the error object", () => {
+      function throwsError() {
         err('popa').orError()
       }
 
-      expect(throwsError).toThrowError(new Error(
-        "Invalid 'orError' usage. Error function was not specified and error type is not Error.",
-      ))
+      expect(throwsError).toThrowError(new Error('popa'))
     })
   })
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -160,13 +160,13 @@ describe('Result.Ok', () => {
     })
 
     it('NULL is a valid value', () => {
-      const result = ok<any, Error>(null).or(42)
+      const result = ok<number | null, Error>(null).or(42)
 
       expect(result).toBe(null)
     })
 
     it('undefined is not a valid value', () => {
-      const result = ok<any, Error>(undefined).or(42)
+      const result = ok<number | undefined, Error>(undefined).or(42)
 
       expect(result).toBe(42)
     })
@@ -180,13 +180,13 @@ describe('Result.Ok', () => {
     })
 
     it('NULL is a valid value', () => {
-      const result = ok<any, Error>(null).orGet(() => 42)
+      const result = ok<number | null, Error>(null).orGet(() => 42)
 
       expect(result).toBe(null)
     })
 
     it('undefined is not a valid value', () => {
-      const result = ok<any, Error>(undefined).orGet(() => 42)
+      const result = ok<number | undefined, Error>(undefined).orGet(() => 42)
 
       expect(result).toBe(42)
     })
@@ -347,7 +347,9 @@ describe('Result.Err', () => {
         err('popa').orError()
       }
 
-      expect(throwsError).toThrowError(new Error("Invalid 'orError' usage. Error function was not specified and error type is not Error."))
+      expect(throwsError).toThrowError(new Error(
+        "Invalid 'orError' usage. Error function was not specified and error type is not Error.",
+      ))
     })
   })
 })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -151,6 +151,54 @@ describe('Result.Ok', () => {
 
     expect(val.value).toBe('safe to read')
   })
+
+  describe('or', () => {
+    it('Specified value wins default', () => {
+      const result = ok(12).or(42)
+
+      expect(result).toBe(12)
+    })
+
+    it('NULL is a valid value', () => {
+      const result = ok<any, Error>(null).or(42)
+
+      expect(result).toBe(null)
+    })
+
+    it('undefined is not a valid value', () => {
+      const result = ok<any, Error>(undefined).or(42)
+
+      expect(result).toBe(42)
+    })
+  })
+
+  describe('orGet', () => {
+    it('Specified value wins default', () => {
+      const result = ok(12).orGet(() => 42)
+
+      expect(result).toBe(12)
+    })
+
+    it('NULL is a valid value', () => {
+      const result = ok<any, Error>(null).orGet(() => 42)
+
+      expect(result).toBe(null)
+    })
+
+    it('undefined is not a valid value', () => {
+      const result = ok<any, Error>(undefined).orGet(() => 42)
+
+      expect(result).toBe(42)
+    })
+  })
+
+  describe('orError', () => {
+    it('On success do nothing', () => {
+      const result = ok(12).orError()
+
+      expect(result).toBe(12)
+    })
+  })
 })
 
 describe('Result.Err', () => {
@@ -259,6 +307,48 @@ describe('Result.Err', () => {
     const okVal = err(12)
 
     expect(okVal._unsafeUnwrapErr()).toBe(12)
+  })
+
+  describe('or', () => {
+    it('Use default value on any err()', () => {
+      const result = err(new Error()).or(42)
+
+      expect(result).toBe(42)
+    })
+  })
+
+  describe('orGet', () => {
+    it('Use supplied result on any err()', () => {
+      const result = err(new Error()).orGet(() => 42)
+
+      expect(result).toBe(42)
+    })
+  })
+
+  describe('orError', () => {
+    it("Throws result's error type", () => {
+      function throwsError () {
+        err(new Error('popa')).orError()
+      }
+
+      expect(throwsError).toThrowError(new Error('popa'))
+    })
+
+    it('Creates an error and throws it', () => {
+      function throwsError () {
+        err('popa').orError((er) => new Error(er))
+      }
+
+      expect(throwsError).toThrowError(new Error('popa'))
+    })
+
+    it("Invalid 'orError' usage example", () => {
+      function throwsError () {
+        err('popa').orError()
+      }
+
+      expect(throwsError).toThrowError(new Error("Invalid 'orError' usage. Error function was not specified and error type is not Error."))
+    })
   })
 })
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -327,7 +327,7 @@ describe('Result.Err', () => {
 
   describe('orError', () => {
     it("Throws result's error type", () => {
-      function throwsError () {
+      function throwsError() {
         err(new Error('popa')).orError()
       }
 
@@ -342,7 +342,7 @@ describe('Result.Err', () => {
       expect(throwsError).toThrowError(new Error('popa'))
     })
 
-    it("Cast to string the error object", () => {
+    it('Cast to string the error object', () => {
       function throwsError() {
         err('popa').orError()
       }


### PR DESCRIPTION
Hi!

I've added the so-called `termination` methods for returning a real value (or throwing an `Error` in case of `Err`).

The methods are useful when you want to **fail fast**, like here:

```typescript
// the method `get(string)` returns `Result<any, Error>`
const value = from(json).get('user.name').orError()
``` 

In the example above I don't want to handle an invalid value, I just want to get a proper result or throw an exception (in this case, it specified as a `Err` part).

Another example is for default values, where I want to use a default value if `Result` has `undefined` or `Err` value, like here:

```typescript
const value = from(json).get('user.name').or('Artem')
```
