### PR TITLE
Fix Result.andThen signature for the f: (t) => ResultAsync case

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,10 +317,9 @@ parseResult.isErr() // true
 
 ### `Result.andThen` (method)
 
-Same idea as `map` above. Except you must return a new `Result` or `ResultAsync`.
+Same idea as `map` above. Except you must return a new `Result`.
 
-If the provided method returns a `Result` the returned value will be a `Result`.  
-If the provided method returns a `ResultAsync` the returned value will be a `ResultAsync`.
+The returned value will be a `Result`.
 
 This is useful for when you need to do a subsequent computation using the inner `T` value, but that computation might fail.
 
@@ -332,9 +331,6 @@ This is useful for when you need to do a subsequent computation using the inner 
 
 type AndThenFunc = (t:  T) => Result<U, E>
 andThen<U>(f: AndThenFunc): Result<U, E> { ... }
-
-type AndThenAsyncFunc = (t:  T) => ResultAsync<U, E>
-andThen<U>(f: AndThenAsyncFunc): ResultAsync<U, E> { ... }
 
 ```
 
@@ -370,6 +366,23 @@ const nested = ok(ok(1234))
 
 // notNested is a Ok(1234)
 const notNested = nested.andThen(innerResult => innerResult)
+```
+
+---
+
+### `Result.asyncAndThen` (method)
+
+Same idea as `andThen` above. Except you must return a new `ResultAsync`.
+
+The returned value will be a `ResultAsync`.
+
+**Signature:**
+
+```typescript
+
+type AndThenAsyncFunc = (t:  T) => ResultAsync<U, E>
+asyncAndThen<U>(f: AndThenAsyncFunc): ResultAsync<U, E> { ... }
+
 ```
 
 ---

--- a/src/result.ts
+++ b/src/result.ts
@@ -31,9 +31,11 @@ export class Ok<T, E> {
   // add info on how this is really useful for converting a
   // Result<Result<T, E2>, E1>
   // into a Result<T, E2>
-  andThen<U>(f: (t: T) => ResultAsync<U, E>): ResultAsync<U, E>
-  andThen<U>(f: (t: T) => Result<U, E>): Result<U, E>
-  andThen<U>(f: (t: T) => Result<U, E> | ResultAsync<U, E>): Result<U, E> | ResultAsync<U, E> {
+  andThen<U>(f: (t: T) => Result<U, E>): Result<U, E> {
+    return f(this.value)
+  }
+
+  asyncAndThen<U>(f: (t: T) => ResultAsync<U, E>): ResultAsync<U, E> {
     return f(this.value)
   }
 
@@ -75,12 +77,14 @@ export class Err<T, E> {
     return err(f(this.error))
   }
 
-  andThen<U>(_f: (t: T) => Result<U, E>): Result<U, E>
-  // Since _f is ignored for Err, the return type is always a Result
-  andThen<U>(_f: (t: T) => ResultAsync<U, E>): Result<U, E>
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  andThen<U>(_f: (t: T) => Result<U, E> | ResultAsync<U, E>): Result<U, E> {
+  andThen<U>(_f: (t: T) => Result<U, E>): Result<U, E> {
     return err(this.error)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  asyncAndThen<U>(_f: (t: T) => ResultAsync<U, E>): ResultAsync<U, E> {
+    return errAsync<U, E>(this.error)
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Addresses #53 

- I changed the signature of `Result.andThen` to only accept functions that return a `Result`.
- I created a new `Result.asyncAndThen` method that accepts functions that return a `ResultAsync`
- I updated tests for `Err.andThen` and `Ok.andThen` and added tests for `asyncAndThen`
- I updated the docs