### PR TITLE
Make ResultAsync<T,E> implement PromiseLike<Result<T,E>>

### DIFF
--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -1,7 +1,7 @@
 import { Result, Ok, Err } from './'
 import { logWarning } from './_internals/log'
 
-export class ResultAsync<T, E> {
+export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
   private _promise: Promise<Result<T, E>>
 
   constructor(res: Promise<Result<T, E>>) {
@@ -70,9 +70,12 @@ export class ResultAsync<T, E> {
     return this._promise.then((res) => res.unwrapOr(t))
   }
 
-  // Makes ResultAsync awaitable
-  then<A>(successCallback: (res: Result<T, E>) => A): Promise<A> {
-    return this._promise.then(successCallback)
+  // Makes ResultAsync implement PromiseLike<Result>
+  then<A, B>(
+    successCallback?: (res: Result<T, E>) => A | PromiseLike<A>,
+    failureCallback?: (reason: unknown) => B | PromiseLike<B>,
+  ): PromiseLike<A | B> {
+    return this._promise.then(successCallback, failureCallback)
   }
 }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -29,7 +29,7 @@ describe('Result.Ok', () => {
 
   it('Maps over an Ok value', () => {
     const okVal = ok(12)
-    const mapFn = jest.fn(number => number.toString())
+    const mapFn = jest.fn((number) => number.toString())
 
     const mapped = okVal.map(mapFn)
 
@@ -39,7 +39,7 @@ describe('Result.Ok', () => {
   })
 
   it('Skips `mapErr`', () => {
-    const mapErrorFunc = jest.fn(_error => 'mapped error value')
+    const mapErrorFunc = jest.fn((_error) => 'mapped error value')
 
     const notMapped = ok(12).mapErr(mapErrorFunc)
 
@@ -51,7 +51,7 @@ describe('Result.Ok', () => {
     it('Maps to an Ok', () => {
       const okVal = ok(12)
 
-      const flattened = okVal.andThen(_number => {
+      const flattened = okVal.andThen((_number) => {
         // ...
         // complex logic
         // ...
@@ -65,7 +65,7 @@ describe('Result.Ok', () => {
     it('Maps to an Err', () => {
       const okval = ok(12)
 
-      const flattened = okval.andThen(_number => {
+      const flattened = okval.andThen((_number) => {
         // ...
         // complex logic
         // ...
@@ -74,7 +74,7 @@ describe('Result.Ok', () => {
 
       expect(flattened.isOk()).toBe(false)
 
-      const nextFn = jest.fn(_val => ok('noop'))
+      const nextFn = jest.fn((_val) => ok('noop'))
 
       flattened.andThen(nextFn)
 
@@ -90,7 +90,7 @@ describe('Result.Ok', () => {
   it('Maps to a ResultAsync', async () => {
     const okVal = ok(12)
 
-    const flattened = okVal.asyncAndThen(_number => {
+    const flattened = okVal.asyncAndThen((_number) => {
       // ...
       // complex async logic
       // ...
@@ -106,7 +106,7 @@ describe('Result.Ok', () => {
   })
 
   it('Maps to a promise', async () => {
-    const asyncMapper = jest.fn(_val => {
+    const asyncMapper = jest.fn((_val) => {
       // ...
       // complex logic
       // ..
@@ -131,8 +131,8 @@ describe('Result.Ok', () => {
   })
 
   it('Matches on an Ok', () => {
-    const okMapper = jest.fn(_val => 'weeeeee')
-    const errMapper = jest.fn(_val => 'wooooo')
+    const okMapper = jest.fn((_val) => 'weeeeee')
+    const errMapper = jest.fn((_val) => 'wooooo')
 
     const matched = ok(12).match(okMapper, errMapper)
 
@@ -171,7 +171,7 @@ describe('Result.Err', () => {
   it('Skips `map`', () => {
     const errVal = err('I am your father')
 
-    const mapper = jest.fn(_value => 'noooo')
+    const mapper = jest.fn((_value) => 'noooo')
 
     const hopefullyNotMapped = errVal.map(mapper)
 
@@ -200,7 +200,7 @@ describe('Result.Err', () => {
   it('Skips over andThen', () => {
     const errVal = err('Yolo')
 
-    const mapper = jest.fn(_val => ok<string, string>('yooyo'))
+    const mapper = jest.fn((_val) => ok<string, string>('yooyo'))
 
     const hopefullyNotFlattened = errVal.andThen(mapper)
 
@@ -212,7 +212,7 @@ describe('Result.Err', () => {
   it('Transforms error into ResultAsync within `asyncAndThen`', async () => {
     const errVal = err('Yolo')
 
-    const asyncMapper = jest.fn(_val => okAsync<string, string>('yooyo'))
+    const asyncMapper = jest.fn((_val) => okAsync<string, string>('yooyo'))
 
     const hopefullyNotFlattened = errVal.asyncAndThen(asyncMapper)
 
@@ -224,7 +224,7 @@ describe('Result.Err', () => {
   })
 
   it('Does not invoke callback within `asyncMap`', async () => {
-    const asyncMapper = jest.fn(_val => {
+    const asyncMapper = jest.fn((_val) => {
       // ...
       // complex logic
       // ..
@@ -250,8 +250,8 @@ describe('Result.Err', () => {
   })
 
   it('Matches on an Err', () => {
-    const okMapper = jest.fn(_val => 'weeeeee')
-    const errMapper = jest.fn(_val => 'wooooo')
+    const okMapper = jest.fn((_val) => 'weeeeee')
+    const errMapper = jest.fn((_val) => 'wooooo')
 
     const matched = err(12).match(okMapper, errMapper)
 
@@ -279,11 +279,7 @@ describe('Utils', () => {
   describe('`combine`', () => {
     describe('Sync `combine`', () => {
       it('Combines a list of results into an Ok value', () => {
-        const resultList = [
-          ok(123),
-          ok(456),
-          ok(789),
-        ]
+        const resultList = [ok(123), ok(456), ok(789)]
 
         const result = combine(resultList)
 
@@ -308,11 +304,7 @@ describe('Utils', () => {
 
     describe('Async `combine`', () => {
       it('Combines a list of async results into an Ok value', async () => {
-        const asyncResultList = [
-          okAsync(123),
-          okAsync(456),
-          okAsync(789),
-        ]
+        const asyncResultList = [okAsync(123), okAsync(456), okAsync(789)]
 
         const result = await combine(asyncResultList)
 
@@ -2496,35 +2488,47 @@ describe('ResultAsync', () => {
     expect(err._unsafeUnwrapErr()).toEqual('Wrong format')
   })
 
-  it('Is chainable like any Promise', async () => {
-    // For a success value
-    const asyncValChained = okAsync(12).then(res => {
-      if (res.isOk()) {
-        return res.value + 2
-      }
+  describe('acting as a Promise<Result>', () => {
+    it('Is chainable like any Promise', async () => {
+      // For a success value
+      const asyncValChained = okAsync(12).then((res) => {
+        if (res.isOk()) {
+          return res.value + 2
+        }
+      })
+
+      expect(asyncValChained).toBeInstanceOf(Promise)
+      const val = await asyncValChained
+      expect(val).toEqual(14)
+
+      // For an error
+      const asyncErrChained = errAsync('Oops').then((res) => {
+        if (res.isErr()) {
+          return res.error + '!'
+        }
+      })
+
+      expect(asyncErrChained).toBeInstanceOf(Promise)
+      const err = await asyncErrChained
+      expect(err).toEqual('Oops!')
     })
 
-    expect(asyncValChained).toBeInstanceOf(Promise)
-    const val = await asyncValChained
-    expect(val).toEqual(14)
+    it('Can be used with Promise.all', async () => {
+      const allResult = await Promise.all([okAsync<string, Error>('1')])
 
-    // For an error
-    const asyncErrChained = errAsync('Oops').then(res => {
-      if (res.isErr()) {
-        return res.error + '!'
-      }
+      expect(allResult).toHaveLength(1)
+      expect(allResult[0]).toBeInstanceOf(Ok)
+      if (!(allResult[0] instanceof Ok)) return
+      expect(allResult[0].isOk()).toBe(true)
+      expect(allResult[0]._unsafeUnwrap()).toEqual('1')
     })
-
-    expect(asyncErrChained).toBeInstanceOf(Promise)
-    const err = await asyncErrChained
-    expect(err).toEqual('Oops!')
   })
 
   describe('map', () => {
     it('Maps a value using a synchronous function', async () => {
       const asyncVal = okAsync(12)
 
-      const mapSyncFn = jest.fn(number => number.toString())
+      const mapSyncFn = jest.fn((number) => number.toString())
 
       const mapped = asyncVal.map(mapSyncFn)
 
@@ -2540,7 +2544,7 @@ describe('ResultAsync', () => {
     it('Maps a value using an asynchronous function', async () => {
       const asyncVal = okAsync(12)
 
-      const mapAsyncFn = jest.fn(number => Promise.resolve(number.toString()))
+      const mapAsyncFn = jest.fn((number) => Promise.resolve(number.toString()))
 
       const mapped = asyncVal.map(mapAsyncFn)
 
@@ -2556,7 +2560,7 @@ describe('ResultAsync', () => {
     it('Skips an error', async () => {
       const asyncErr = errAsync<number, string>('Wrong format')
 
-      const mapSyncFn = jest.fn(number => number.toString())
+      const mapSyncFn = jest.fn((number) => number.toString())
 
       const notMapped = asyncErr.map(mapSyncFn)
 
@@ -2574,7 +2578,7 @@ describe('ResultAsync', () => {
     it('Maps an error using a synchronous function', async () => {
       const asyncErr = errAsync('Wrong format')
 
-      const mapErrSyncFn = jest.fn(str => 'Error: ' + str)
+      const mapErrSyncFn = jest.fn((str) => 'Error: ' + str)
 
       const mappedErr = asyncErr.mapErr(mapErrSyncFn)
 
@@ -2590,7 +2594,7 @@ describe('ResultAsync', () => {
     it('Maps an error using an asynchronous function', async () => {
       const asyncErr = errAsync('Wrong format')
 
-      const mapErrAsyncFn = jest.fn(str => Promise.resolve('Error: ' + str))
+      const mapErrAsyncFn = jest.fn((str) => Promise.resolve('Error: ' + str))
 
       const mappedErr = asyncErr.mapErr(mapErrAsyncFn)
 
@@ -2606,7 +2610,7 @@ describe('ResultAsync', () => {
     it('Skips a value', async () => {
       const asyncVal = okAsync(12)
 
-      const mapErrSyncFn = jest.fn(str => 'Error: ' + str)
+      const mapErrSyncFn = jest.fn((str) => 'Error: ' + str)
 
       const notMapped = asyncVal.mapErr(mapErrSyncFn)
 
@@ -2672,8 +2676,8 @@ describe('ResultAsync', () => {
 
   describe('match', () => {
     it('Matches on an Ok', async () => {
-      const okMapper = jest.fn(_val => 'weeeeee')
-      const errMapper = jest.fn(_val => 'wooooo')
+      const okMapper = jest.fn((_val) => 'weeeeee')
+      const errMapper = jest.fn((_val) => 'wooooo')
 
       const matched = await okAsync(12).match(okMapper, errMapper)
 
@@ -2683,8 +2687,8 @@ describe('ResultAsync', () => {
     })
 
     it('Matches on an Error', async () => {
-      const okMapper = jest.fn(_val => 'weeeeee')
-      const errMapper = jest.fn(_val => 'wooooo')
+      const okMapper = jest.fn((_val) => 'weeeeee')
+      const errMapper = jest.fn((_val) => 'wooooo')
 
       const matched = await errAsync('bad').match(okMapper, errMapper)
 
@@ -2718,7 +2722,7 @@ describe('ResultAsync', () => {
     })
 
     it('Accepts an error handler as a second argument', async () => {
-      const res = ResultAsync.fromPromise(Promise.reject('No!'), e => new Error('Oops: ' + e))
+      const res = ResultAsync.fromPromise(Promise.reject('No!'), (e) => new Error('Oops: ' + e))
 
       expect(res).toBeInstanceOf(ResultAsync)
 


### PR DESCRIPTION
This enables using Promise.all() and others on ResultAsync[].