### PR TITLE
Add fromThrowable utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For asynchronous tasks, `neverthrow` offers a `ResultAsync` class which wraps a 
     - [`Result.asyncAndThen` (method)](#resultasyncandthen-method)
     - [`Result.match` (method)](#resultmatch-method)
     - [`Result.asyncMap` (method)](#resultasyncmap-method)
+    - [`Result.fromThrowable`](#resultfromthrowable)
   + [Asynchronous API (`ResultAsync`)](#asynchronous-api-resultasync)
     - [`okAsync`](#okasync)
     - [`errAsync`](#errasync)
@@ -425,6 +426,37 @@ Note that in the above example if `parseHeaders` returns an `Err` then `.map` an
 
 ---
 
+#### `Result.fromThrowable`
+
+The JavaScript community has agreed on the convention of throwing exceptions.
+As such, when interfacing with third party libraries it's imperative that you
+wrap third-party code in try / catch  blocks.
+
+This function will create a new function that returns an `Err` when the original
+function throws.
+
+It is not possible to know the types of the errors thrown in the original
+function, therefore it is recommended to use the second argument `errorFn` to
+map what is thrown to a known type.
+
+**Example**:
+
+```typescript
+import { fromThrowable } from 'neverthrow'
+
+type ParseError = { message: string }
+const toParseError = (): ParseError => ({message: "Parse Error" })
+
+const safeJsonParse = fromThrowable(JSON.parse, toParseError)
+
+// the function can now be used safely, if the function throws, the result will be an Err
+const res = safeJsonParse("{");
+```
+
+[⬆️  Back to top](#toc)
+
+---
+
 ### Asynchronous API (`ResultAsync`)
 
 #### `okAsync`
@@ -745,6 +777,7 @@ function combine<T, E>(asyncResultList: ResultAsync<T, E>[]): ResultAsync<T[], E
 
 
 ---
+
 
 If you find this package useful, please consider [sponsoring me](https://github.com/sponsors/supermacro/) or simply [buying me a coffee](https://ko-fi.com/gdelgado)!
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,29 @@
 import { ResultAsync, errAsync } from './'
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Result {
+  /**
+   * Wraps a function with a try catch, creating a new function with the same
+   * arguments but returning `Ok` if successful, `Err` if the function throws
+   *
+   * @param fn function to wrap with ok on success or err on failure
+   * @param errorFn when an error is thrown, this will wrap the error result if provided
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function fromThrowable<Fn extends (...args: readonly unknown[]) => any, E>(
+    fn: Fn,
+    errorFn?: (e: unknown) => E,
+  ): (...args: Parameters<Fn>) => Result<ReturnType<Fn>, E> {
+    return (...args) => {
+      try {
+        const result = fn(...args)
+        return ok(result)
+      } catch (e) {
+        return err(errorFn ? errorFn(e) : e)
+      }
+    }
+  }
+}
 export type Result<T, E> = Ok<T, E> | Err<T, E>
 
 // eslint-disable-next-line @typescript-eslint/no-use-before-define


### PR DESCRIPTION
It is common within javascript libraries to throw within a synchronous function

This adds a utility function fromThowable that wraps a function and creates a
function with the same signature except instead of throwing, a Result will be
returned. Ok if the original function succeds, or Err if the function throws.

As we cannot infer the type of the thrown error, this will be of unknown type
unless a mapping function is provided.

Discussed in #203