### PR TITLE
Remove unused eslint disable no-use-before-define comments

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -26,10 +26,8 @@ export namespace Result {
 }
 export type Result<T, E> = Ok<T, E> | Err<T, E>
 
-// eslint-disable-next-line @typescript-eslint/no-use-before-define
 export const ok = <T, E>(value: T): Ok<T, E> => new Ok(value)
 
-// eslint-disable-next-line @typescript-eslint/no-use-before-define
 export const err = <T, E>(err: E): Err<T, E> => new Err(err)
 
 export class Ok<T, E> {


### PR DESCRIPTION
These linting steps do not create any lint errors in for `lint`, `typecheck`,
or `build`. The comments disabling these rules are no longer required
