### PR TITLE
Make ok and err comparable

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -71,7 +71,7 @@ export class Ok<T, E> {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  match = <A>(ok: (t: T) => A, _err: (e: E) => A): A => {
+  match<A>(ok: (t: T) => A, _err: (e: E) => A): A {
     return ok(this.value)
   }
 
@@ -123,7 +123,7 @@ export class Err<T, E> {
     return v
   }
 
-  match = <A>(_ok: (t: T) => A, err: (e: E) => A): A => {
+  match<A>(_ok: (t: T) => A, err: (e: E) => A): A {
     return err(this.error)
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -26,6 +26,11 @@ describe('Result.Ok', () => {
     expect(okVal._unsafeUnwrap()).toBeUndefined()
   })
 
+  it('Is comparable', () => {
+    expect(ok(42)).toEqual(ok(42))
+    expect(ok(42)).not.toEqual(ok(43))
+  })
+
   it('Maps over an Ok value', () => {
     const okVal = ok(12)
     const mapFn = jest.fn((number) => number.toString())
@@ -165,6 +170,11 @@ describe('Result.Err', () => {
     expect(errVal.isOk()).toBe(false)
     expect(errVal.isErr()).toBe(true)
     expect(errVal).toBeInstanceOf(Err)
+  })
+
+  it('Is comparable', () => {
+    expect(err(42)).toEqual(err(42))
+    expect(err(42)).not.toEqual(err(43))
   })
 
   it('Skips `map`', () => {


### PR DESCRIPTION
Looking into #211 a bit more closely, I noticed that it is really only the `match` function that for some reason wasn't implemented as a function attached to the prototype, but rather as a property. This not only has an unnecessary memory overhead, but was also the reason why `Ok` and `Err` instances weren't comparable. I'm not sure why it has been done like that, but at least changing it does not break any test and would enable deep comparison.

Also, in the case of an coincidental `expect(ok(42)).toEqual(err(42))` Jest actually prints something quite meaningful:

![image](https://user-images.githubusercontent.com/3620703/102872457-fe006800-443f-11eb-8c7f-89451d3034a6.png)

So they cannot accidentally match because of the different property name. On first glance this would basically solve #211 for me.