### PR TITLE
Make unwrap exception test friendly

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -80,7 +80,7 @@ export class Ok<T, E> {
   }
 
   _unsafeUnwrapErr(): E {
-    throw new Error('Called `_unsafeUnwrapErr` on an Ok')
+    throw { message: 'Called `_unsafeUnwrapErr` on an Ok', error: this.value }
   }
 }
 
@@ -128,7 +128,7 @@ export class Err<T, E> {
   }
 
   _unsafeUnwrap(): T {
-    throw new Error('Called `_unsafeUnwrap` on an Err')
+    throw { message: 'Called `_unsafeUnwrap` on an Err', error: this.error }
   }
 
   _unsafeUnwrapErr(): E {

--- a/src/result.ts
+++ b/src/result.ts
@@ -80,7 +80,7 @@ export class Ok<T, E> {
   }
 
   _unsafeUnwrapErr(): E {
-    throw { message: 'Called `_unsafeUnwrapErr` on an Ok', error: this.value }
+    throw { message: 'Called `_unsafeUnwrapErr` on an Ok', value: this.value }
   }
 }
 


### PR DESCRIPTION
This would be my shot at the other action item regarding #211.

At first I tried to use a custom `UnwrapError` which inherits from `Error`, and attach the extra value/error there. The problem is that Jest seems to only only ever show the `message` of an exception as soon as the `instanceof Error` check is true. Not sure if there is a way around it. With this behavior of Jest the only option would have been to attach `this.value` / `this.error` to the message itself, but that sucks because, because it would most likely require some `JSON.stringify`, and it prevents the final printing from pretty printing the object properly.

Then I figured: The `_unsafeUnwrap` technically doesn't really need to throw an error that is instance of `Error`. Perhaps it even shouldn't. It is not something this is supposed to be caught in normal code anyway, so the solution can focus on the test case. It turns out that simply throwing a plain object gives very nice test output. Examples:

```ts
it('Makes nice unwrap error 1', () => {
  const okVal = err(42)
  expect(okVal._unsafeUnwrap()).toBe('whatever')
})

it('Makes nice unwrap error 2', () => {
  const okVal = ok({ foo: ['some', 'more', 'complex', 'data'], bar: [1, 2, 3, 4] })
  expect(okVal._unsafeUnwrapErr()).toBe('whatever')
})
```

![image](https://user-images.githubusercontent.com/3620703/102913745-763a4e00-447f-11eb-9445-6ba804d15ae9.png)

What do you think?
