### PR TITLE
Optional stack trace

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/semi': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/member-delimiter-style': ['error', {
       multiline: {

--- a/README.md
+++ b/README.md
@@ -785,9 +785,9 @@ function combine<T, E>(asyncResultList: ResultAsync<T, E>[]): ResultAsync<T[], E
 
 `Result` instances have two unsafe methods, aptly called `_unsafeUnwrap` and `_unsafeUnwrapErr` which **should only be used in a test environment**. 
 
-`_unsafeUnwrap` takes a `Result<T, E>` and returns a `T` when the result is an `Ok`, otherwise it throws.
+`_unsafeUnwrap` takes a `Result<T, E>` and returns a `T` when the result is an `Ok`, otherwise it throws a custom object.
 
-`_unsafeUnwrapErr` takes a `Result<T, E>` and returns a `E` when the result is an `Err`, otherwise it throws.
+`_unsafeUnwrapErr` takes a `Result<T, E>` and returns a `E` when the result is an `Err`, otherwise it throws a custom object.
 
 That way you can do something like:
 
@@ -796,6 +796,16 @@ expect(myResult._unsafeUnwrap()).toBe(someExpectation)
 ```
 
 However, do note that `Result` instances are comparable. So you don't necessarily need to unwrap them in order to assert expectations in your tests.
+
+By default, the thrown value does not contain a stack trace. This is because stack trace generation [makes error messages in Jest harder to understand](https://github.com/supermacro/neverthrow/pull/215). If you want stack traces to be generated, call `_unsafeUnwrap` and / or `_unsafeUnwrapErr` with a config object:
+
+```typescript
+_unsafeUnwrapErr({
+  withStackTrace: true,
+})
+
+// ^ Now the error object will have a `.stack` property containing the current stack
+```
 
 
 ---

--- a/src/_internals/error.ts
+++ b/src/_internals/error.ts
@@ -1,14 +1,29 @@
 import { Result } from '../result'
 
+export interface ErrorConfig {
+  withStackTrace: boolean
+}
+
+const defaultErrorConfig: ErrorConfig = {
+  withStackTrace: false,
+}
+
 // Custom error object
 // Context / discussion: https://github.com/supermacro/neverthrow/pull/215
-export const createNeverThrowError = <T, E>(message: string, result: Result<T, E>) => {
+export const createNeverThrowError = <T, E>(
+  message: string,
+  result: Result<T, E>,
+  config: ErrorConfig = defaultErrorConfig,
+) => {
   const data = result.isOk()
     ? { type: 'Ok', value: result.value }
     : { type: 'Err', value: result.error }
 
+  const maybeStack = config.withStackTrace ? new Error().stack : undefined
+
   return {
     data,
     message,
+    stack: maybeStack,
   }
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,5 @@
 import { ResultAsync, errAsync } from './'
-import { createNeverThrowError } from './_internals/error'
+import { createNeverThrowError, ErrorConfig } from './_internals/error'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace Result {
@@ -76,12 +76,12 @@ export class Ok<T, E> {
     return ok(this.value)
   }
 
-  _unsafeUnwrap(): T {
+  _unsafeUnwrap(_?: ErrorConfig): T {
     return this.value
   }
 
-  _unsafeUnwrapErr(): E {
-    throw createNeverThrowError('Called `_unsafeUnwrapErr` on an Ok', this)
+  _unsafeUnwrapErr(config?: ErrorConfig): E {
+    throw createNeverThrowError('Called `_unsafeUnwrapErr` on an Ok', this, config)
   }
 }
 
@@ -128,11 +128,11 @@ export class Err<T, E> {
     return err(this.error)
   }
 
-  _unsafeUnwrap(): T {
-    throw createNeverThrowError('Called `_unsafeUnwrap` on an Err', this)
+  _unsafeUnwrap(config?: ErrorConfig): T {
+    throw createNeverThrowError('Called `_unsafeUnwrap` on an Err', this, config)
   }
 
-  _unsafeUnwrapErr(): E {
+  _unsafeUnwrapErr(_?: ErrorConfig): E {
     return this.error
   }
 }


### PR DESCRIPTION
Context: https://github.com/supermacro/neverthrow/issues/211

Allows the caller of `_unsafeUnwrap` and `_unsafeUnwrapErr` to enable stack trace generation in the event that these methods are being used in a non-testing environment.