### PR TITLE
Export factories directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ For asynchronous tasks, `neverthrow` offers a `ResultAsync` class which wraps a 
     - [`ResultAsync.match` (method)](#resultasyncmatch-method)
   + [Utilities](#utilities)
     - [`combine`](#combine)
+    - [`fromThrowable`](#fromThrowable)
+    - [`fromPromise`](#fromPromise)
+    - [`fromSafePromise`](#fromSafePromise)
   + [Testing](#testing)
 * [A note on the Package Name](#a-note-on-the-package-name)
 
@@ -900,6 +903,36 @@ function combine<T, E>(asyncResultList: ResultAsync<T, E>[]): ResultAsync<T[], E
 
 
 ---
+
+#### fromThrowable
+
+Top level export of `Result.fromThrowable`.
+
+Please find documentation at [Result.fromThrowable](#resultfromthrowable-static-class-method)
+
+[⬆️  Back to top](#toc)
+
+
+---
+
+#### fromPromise
+
+Top level export of `ResultAsync.fromPromise`.
+
+Please find documentation at [ResultAsync.fromPromise](#resultasyncfrompromise-static-class-method)
+
+[⬆️  Back to top](#toc)
+
+
+---
+
+#### fromSafePromise
+
+Top level export of `ResultAsync.fromSafePromise`.
+
+Please find documentation at [ResultAsync.fromSafePromise](#resultasyncfromsafepromise-static-class-method)
+
+[⬆️  Back to top](#toc)
 
 ### Testing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { Result, ok, Ok, err, Err } from './result'
-export { ResultAsync, okAsync, errAsync } from './result-async'
+export { Result, ok, Ok, err, Err, fromThrowable } from './result'
+export { ResultAsync, okAsync, errAsync, fromPromise, fromSafePromise } from './result-async'
 export { combine } from './utils'

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -93,3 +93,6 @@ export const okAsync = <T, E>(value: T): ResultAsync<T, E> =>
 
 export const errAsync = <T, E>(err: E): ResultAsync<T, E> =>
   new ResultAsync(Promise.resolve(new Err<T, E>(err)))
+
+export const fromPromise = ResultAsync.fromPromise
+export const fromSafePromise = ResultAsync.fromSafePromise

--- a/src/result.ts
+++ b/src/result.ts
@@ -150,3 +150,5 @@ export class Err<T, E> {
     return this.error
   }
 }
+
+export const fromThrowable = Result.fromThrowable

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { ok, err, Ok, Err, Result, ResultAsync, okAsync, errAsync } from '../src'
+import { ok, err, Ok, Err, Result, ResultAsync, okAsync, errAsync, fromPromise, fromSafePromise, fromThrowable } from '../src'
 import { combine } from '../src/utils'
 
 describe('Result.Ok', () => {
@@ -345,6 +345,10 @@ describe('Result.fromThrowable', () => {
     expect(result.isErr()).toBe(true)
     expect(result).toBeInstanceOf(Err)
     expect(result._unsafeUnwrapErr()).toEqual({ message: 'error' })
+  })
+
+  it('has a top level export', () => {
+      expect(fromThrowable).toBe(Result.fromThrowable)
   })
 })
 
@@ -725,6 +729,10 @@ describe('ResultAsync', () => {
       expect(val.isOk()).toBe(true)
       expect(val._unsafeUnwrap()).toEqual(12)
     })
+
+    it('has a top level export', () => {
+      expect(fromSafePromise).toBe(ResultAsync.fromSafePromise)
+    })
   })
 
   describe('fromPromise', () => {
@@ -736,6 +744,10 @@ describe('ResultAsync', () => {
       const val = await res
       expect(val.isErr()).toBe(true)
       expect(val._unsafeUnwrapErr()).toEqual(Error('Oops: No!'))
+    })
+
+    it('has a top level export', () => {
+      expect(fromPromise).toBe(ResultAsync.fromPromise)
     })
   })
 


### PR DESCRIPTION
Hello! This PR is intended to start a discussion for ergonomics.

I have recently discovered this great library and introduced to a colleague of mine. I felt it was a bit awkward to use the available factories, so I am raising this PR to discuss about it.

This PR makes factories available as a top level export.

It will simplify the usage overall, as it will be more straightforward to use.

```
import { fromThrowable } from 'neverthrow'

// instead of

import { Result } from 'neverthrow'

const { fromThrowable } = Result
```