### PR TITLE
Add inline function docs for Ok and Err

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -31,7 +31,129 @@ export const ok = <T, E>(value: T): Ok<T, E> => new Ok(value)
 
 export const err = <T, E>(err: E): Err<T, E> => new Err(err)
 
-export class Ok<T, E> {
+interface IResult<T, E> {
+  /**
+   * Used to check if a `Result` is an `OK`
+   *
+   * @returns `true` if the result is an `OK` variant of Result
+   */
+  isOk(): this is Ok<T, E>
+
+  /**
+   * Used to check if a `Result` is an `Err`
+   *
+   * @returns `true` if the result is an `Err` variant of Result
+   */
+  isErr(): this is Err<T, E>
+
+  /**
+   * Maps a `Result<T, E>` to `Result<U, E>`
+   * by applying a function to a contained `Ok` value, leaving an `Err` value
+   * untouched.
+   *
+   * @param f The function to apply an `OK` value
+   * @returns the result of applying `f` or an `Err` untouched
+   */
+  map<A>(f: (t: T) => A): Result<A, E>
+
+  /**
+   * Maps a `Result<T, E>` to `Result<T, F>` by applying a function to a
+   * contained `Err` value, leaving an `Ok` value untouched.
+   *
+   * This function can be used to pass through a successful result while
+   * handling an error.
+   *
+   * @param f a function to apply to the error `Err` value
+   */
+  mapErr<U>(f: (e: E) => U): Result<T, U>
+
+  /**
+   * Similar to `map` Except you must return a new `Result`.
+   *
+   * This is useful for when you need to do a subsequent computation using the
+   * inner `T` value, but that computation might fail.
+   * Additionally, `andThen` is really useful as a tool to flatten a
+   * `Result<Result<A, E2>, E1>` into a `Result<A, E2>` (see example below).
+   *
+   * @param f The function to apply to the current value
+   */
+  andThen<U, F>(f: (t: T) => Result<U, F>): Result<U, E | F>
+
+  /**
+   * Takes an `Err` value and maps it to a `Result<T, SomeNewType>`.
+   *
+   * This is useful for error recovery.
+   *
+   *
+   * @param f  A function to apply to an `Err` value, leaving `Ok` values
+   * untouched.
+   */
+  orElse<A>(f: (e: E) => Result<T, A>): Result<T, A>
+
+  /**
+   * Similar to `map` Except you must return a new `Result`.
+   *
+   * This is useful for when you need to do a subsequent async computation using
+   * the inner `T` value, but that computation might fail. Must return a ResultAsync
+   *
+   * @param f The function that returns a `ResultAsync` to apply to the current
+   * value
+   */
+  asyncAndThen<U, F>(f: (t: T) => ResultAsync<U, F>): ResultAsync<U, E | F>
+
+  /**
+   * Maps a `Result<T, E>` to `ResultAsync<U, E>`
+   * by applying an async function to a contained `Ok` value, leaving an `Err`
+   * value untouched.
+   *
+   * @param f An async function to apply an `OK` value
+   */
+  asyncMap<U>(f: (t: T) => Promise<U>): ResultAsync<U, E>
+
+  /**
+   * Unwrap the `Ok` value, or return the default if there is an `Err`
+   *
+   * @param v the default value to return if there is an `Err`
+   */
+  unwrapOr(v: T): T
+
+  /**
+   *
+   * Given 2 functions (one for the `Ok` variant and one for the `Err` variant)
+   * execute the function that matches the `Result` variant.
+   *
+   * Match callbacks do not necessitate to return a `Result`, however you can
+   * return a `Result` if you want to.
+   *
+   * `match` is like chaining `map` and `mapErr`, with the distinction that
+   * with `match` both functions must have the same return type.
+   *
+   * @param ok
+   * @param err
+   */
+  match<A>(ok: (t: T) => A, err: (e: E) => A): A
+
+  /**
+   * **This method is unsafe, and should only be used in a test environments**
+   *
+   * Takes a `Result<T, E>` and returns a `T` when the result is an `Ok`, otherwise it throws a custom object.
+   *
+   * @param config
+   */
+  _unsafeUnwrap(config?: ErrorConfig): T
+
+  /**
+   * **This method is unsafe, and should only be used in a test environments**
+   *
+   * takes a `Result<T, E>` and returns a `E` when the result is an `Err`,
+   * otherwise it throws a custom object.
+   *
+   * @param config
+   */
+  _unsafeUnwrapErr(config?: ErrorConfig): E
+}
+
+export class Ok<T, E> implements IResult<T, E> {
   constructor(readonly value: T) {}
 
   isOk(): this is Ok<T, E> {
@@ -50,17 +172,10 @@ export class Ok<T, E> {
   mapErr<U>(_f: (e: E) => U): Result<T, U> {
     return ok(this.value)
   }
-
-  // add info on how this is really useful for converting a
-  // Result<Result<T, E2>, E1>
-  // into a Result<T, E2>
   andThen<U, F>(f: (t: T) => Result<U, F>): Result<U, E | F> {
     return f(this.value)
   }
 
-  /**
-   * Applies a function to an `Err` value, leaving `Ok` values untouched. Useful for error recovery.
-   */
   orElse<A>(_f: (e: E) => Result<T, A>): Result<T, A> {
     return ok(this.value)
   }
@@ -92,7 +207,7 @@ export class Ok<T, E> {
   }
 }
 
-export class Err<T, E> {
+export class Err<T, E> implements IResult<T, E> {
   constructor(readonly error: E) {}
 
   isOk(): this is Ok<T, E> {
@@ -117,9 +232,6 @@ export class Err<T, E> {
     return err(this.error)
   }
 
-  /**
-   * Applies a function to an `Err` value, leaving `Ok` values untouched. Useful for error recovery.
-   */
   orElse<A>(f: (e: E) => Result<T, A>): Result<T, A> {
     return f(this.error)
   }


### PR DESCRIPTION
Based on discussion in #187 

The descriptions are trimmed down versions from the documentation at this stage.

I have created an interface `IResult`, by extending this interface the inline function docs are propagated to both `Ok` and `Error`

Keen to get specifically get some feedback on the descriptions and/or the approach of extending a shared interface