### PR TITLE
Clarify the behavior of ResultAsync on promise rejections

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ const res = ResultAsync.fromPromise(insertIntoDb(myUser), () => new Error('Datab
 
 #### `ResultAsync.fromSafePromise` (static class method)
 
-Same as `ResultAsync.fromPromise` except that the promise never throws, and therefore does not require an error handler. **Ensure you know what you're doing, otherwise a thrown exception within this promise will break any guarantees that neverthrow provides.**
+Same as `ResultAsync.fromPromise` except that it does not handle the rejection of the promise. **Ensure you know what you're doing, otherwise a thrown exception within this promise will cause ResultAsync to reject, instead of resolve to a Result.**
 
 
 **Signature:**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -621,6 +621,11 @@ describe('ResultAsync', () => {
       expect(allResult[0].isOk()).toBe(true)
       expect(allResult[0]._unsafeUnwrap()).toEqual('1')
     })
+
+    it('rejects if the underlying promise is rejected', () => {
+      const asyncResult = new ResultAsync(Promise.reject('oops'))
+      expect(asyncResult).rejects.toBe('oops')
+    })
   })
 
   describe('map', () => {


### PR DESCRIPTION
Instead of invalidating all guarantees completely, guarantee that the rejection of the underlying promise will reject the ResultAsync.

Keep the warning to the user as this is undesirable in most cases.

Solves #257 