### PR TITLE
Fixed #300: Updated fromThrowable type signature to allow inner function to have arguments.

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -11,7 +11,7 @@ export namespace Result {
    * @param errorFn when an error is thrown, this will wrap the error result if provided
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  export function fromThrowable<Fn extends (...args: readonly unknown[]) => any, E>(
+  export function fromThrowable<Fn extends (...args: readonly any[]) => any, E>(
     fn: Fn,
     errorFn?: (e: unknown) => E,
   ): (...args: Parameters<Fn>) => Result<ReturnType<Fn>, E> {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -315,6 +315,19 @@ describe('Result.fromThrowable', () => {
     expect(safeResult).toBeInstanceOf(Ok)
     expect(result).toEqual(safeResult._unsafeUnwrap())
   })
+
+  // Added for issue #300 -- the test here is not so much that expectations are met as that the test compiles.
+  it('Accepts an inner function which takes arguments', () => {
+    const hello = (fname: string): string => `hello, ${fname}`;
+    const safeHello = Result.fromThrowable(hello);
+
+    const result = hello('Dikembe');
+    const safeResult = safeHello('Dikembe');
+
+    expect(safeResult).toBeInstanceOf(Ok);
+    expect(result).toEqual(safeResult._unsafeUnwrap());
+  });
+
   it('Creates a function that returns an err when the inner function throws', () => {
     const thrower = (): string => {
       throw new Error()


### PR DESCRIPTION
Fixes #300 