### PR TITLE
fix(utils/combine): not appending all proxies due to Array.prototype concat internals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5093,10 +5093,22 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-stream": {
@@ -8209,6 +8221,34 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quibble": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.6.tgz",
+      "integrity": "sha512-qYLELbjh2TagaPEs+sDobJnw166zlYHtT8YibCYxxUYl+pGoDqEVjZZhgQXYPhIivb8CrDtEMP9Oshfu8y6jAQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
     "react-is": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
@@ -8599,6 +8639,16 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha1-BXw8mpChJzObudFwSikLt70KHsU=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -8723,10 +8773,28 @@
         "minimatch": "^3.0.4"
       }
     },
+    "testdouble": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.16.3.tgz",
+      "integrity": "sha512-oxGJ9KFuAJBNrpQEGDLj3OD4jRKLV+NhujRnuw5gYelkkZEFzUExijPi8O26RoVMdhc9C3OanKjvZXinmHWqow==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "quibble": "^0.6.6",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
       "dev": true
     },
     "throat": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "rollup": "2.52.7",
     "rollup-plugin-dts": "3.0.1",
     "rollup-plugin-typescript2": "0.29.0",
+    "testdouble": "^3.16.3",
     "ts-jest": "27.0.3",
     "typescript": "4.2.4"
   },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,19 +27,7 @@ export type InferErrTypes<R> = R extends Result<unknown, infer E> ? E : never
 export type InferAsyncOkTypes<R> = R extends ResultAsync<infer T, unknown> ? T : never
 export type InferAsyncErrTypes<R> = R extends ResultAsync<unknown, infer E> ? E : never
 
-const appendValueToEndOfList = <T>(value: T) => (list: T[]): T[] => {
-  // need to wrap `value` inside of an array in order to prevent
-  // Array.prototype.concat from destructuring the contents of `value`
-  // into `list`.
-  //
-  // Otherwise you will receive [ 'hi', 1, 2, 3 ]
-  // when you actually expected a tuple containing [ 'hi', [ 1, 2, 3 ] ]
-  if (Array.isArray(value)) {
-    return list.concat([value])
-  }
-
-  return list.concat(value)
-}
+const appendValueToEndOfList = <T>(value: T) => (list: T[]): T[] => [...list, value]
 
 /**
  * Short circuits on the FIRST Err value that we find

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { ok, err, Ok, Err, Result, ResultAsync, okAsync, errAsync, fromPromise, fromSafePromise, fromThrowable } from '../src'
+import * as td from 'testdouble'
 import { combine, combineWithAllErrors } from '../src/utils'
 
 describe('Result.Ok', () => {
@@ -574,6 +575,27 @@ describe('Utils', () => {
         const result: ExpecteResult = await combineWithAllErrors(heterogenousList)
 
         expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true])
+      })
+    })
+
+    describe('testdouble `combine`', () => {
+      interface ITestInterface {
+        getName(): string
+        setName(name: string): void
+        getAsyncResult(): ResultAsync<ITestInterface, Error>
+      }
+
+      it('Combines `testdouble` proxies from mocks generated via interfaces', async () => {
+        const mock = td.object<ITestInterface>()
+
+        const result = await combine([okAsync(mock)] as const)
+
+        expect(result).toBeDefined()
+        expect(result.isErr()).toBeFalsy()
+        const unwrappedResult = result._unsafeUnwrap()
+
+        expect(unwrappedResult.length).toBe(1)
+        expect(unwrappedResult[0]).toBe(mock)
       })
     })
   })


### PR DESCRIPTION
Switched usage of `Array.prototype.concat` to use ES6 spread operator.
Installed testdouble as a dev dependency and added backing test from #228 

Addresses: `Problem with combine() and Mocks` #228