### PR TITLE
feat(ResultAsync): implement fromSoundPromise

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { Result, ok, Ok, err, Err, fromThrowable } from './result'
 export { ResultAsync, okAsync, errAsync, fromPromise, fromSafePromise } from './result-async'
 export { combine, combineWithAllErrors } from './utils'
+export type { SoundPromise } from './utils'

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -1,4 +1,10 @@
-import { InferOkTypes, InferErrTypes, InferAsyncOkTypes, InferAsyncErrTypes } from './utils'
+import {
+  InferOkTypes,
+  InferErrTypes,
+  InferAsyncOkTypes,
+  InferAsyncErrTypes,
+  SoundPromise,
+} from './utils'
 import { Result, Ok, Err } from './'
 
 export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
@@ -6,6 +12,10 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
 
   constructor(res: Promise<Result<T, E>>) {
     this._promise = res
+  }
+
+  static fromSoundPromise<T, E>(promise: SoundPromise<T, E>): ResultAsync<T, E> {
+    return new ResultAsync(promise)
   }
 
   static fromSafePromise<T, E>(promise: Promise<T>): ResultAsync<T, E> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,8 @@ export type InferErrTypes<R> = R extends Result<unknown, infer E> ? E : never
 export type InferAsyncOkTypes<R> = R extends ResultAsync<infer T, unknown> ? T : never
 export type InferAsyncErrTypes<R> = R extends ResultAsync<unknown, infer E> ? E : never
 
+export type SoundPromise<T, E> = Promise<Result<T, E>>
+
 const appendValueToEndOfList = <T>(value: T) => (list: T[]): T[] => [...list, value]
 
 /**


### PR DESCRIPTION
# Why would someone need this?
There are two ways to create ResultAsync from promises.

## Method 1
Directly calling `new ResultAsync(promise)`.
This is not documented & it is not consistent with other APIs. 

## Method 2
In order to have type safe error handling for promises, the programmer loses type safety with the current implementation.

Without `fromSoundPromise`, creating a `ResultAsync<T,E>` is done like:

![image](https://user-images.githubusercontent.com/44586130/174397350-1ac1483f-43b2-46c2-b9b4-98c9297a0ed6.png)

There isn't any type safety with this approach. 
- Somebody can change line 8 from `throw 'unauthorized'` to `throw 'not-authorized'`.
- Somebody can decide to refactor string exceptions to proper `Error` instances, i.e. `Error('unauthorized')` & `Error('timeout')`

In both of these cases, programmer has to remember to modify one behavior in two different places, without any support from the type system.

Another side effect of not having type safety, is the additional error type `'unknown-error'`. The original function fails with either `'timeout'` or `'unauthorized'` while the Error type on line 14 is `'timeout' | 'unauthorized' | 'unknown-error'`

# Proposed Solution
A function called `fromSoundPromise` that accepts `Promise<Result<T, E>>` and returns `ResultAsync<T, E>`.

This will simplify the above snippet to:
![image](https://user-images.githubusercontent.com/44586130/174398663-c1430db4-a0f0-40a5-a0ca-330989ad4c9f.png)

For convenience, a `SoundPromise<T, E>` type is exported which just an alias for `Promise<Result<T, E>>`.
![image](https://user-images.githubusercontent.com/44586130/174398875-70a8b510-692b-447c-82d6-73184233428e.png)

This is more compatible with async/await syntax. In most cases, a programmer can get `Result<T, E>` by awaiting `SoundPromise<T, E>` without any need for `ResultAsync`.
![image](https://user-images.githubusercontent.com/44586130/174399858-d9376e76-5544-4750-9e76-c4b5e4197007.png)

In more complex scenarios where chaining is required, `ResultAsync` can come to the rescue:
![image](https://user-images.githubusercontent.com/44586130/174399898-8cc8190f-0f30-4aa8-938d-c26d7475e23b.png)

<hr/>

An eslint rule can be added in order to prevent any throw statements which would make promise based error handling 100% typesafe.
Example ESLint Rules:
- [eslint-plugin-functional/no-exceptions](https://github.com/jonaskello/eslint-plugin-functional#no-exceptions) 
- [eslint-plugin-fp/no-throw](https://github.com/jfmengels/eslint-plugin-fp/blob/master/docs/rules/no-throw.md)
 
<br/>
<hr/>
Here is the source code for the images above.

**Not Type Safe:**

```typescript
async function getUserId(): Promise<number> {
  const rand = Math.random()

  if (rand < 0.1) {
    throw 'timeout'
  }
  if (rand < 0.2) {
    throw 'unauthorized'
  }

  return 5
}

const typeSafePromise = ResultAsync.fromPromise(getUserId(), (e: unknown) => {
  if (e == 'timeout') {
    return 'timeout'
  }
  if (e == 'unauthorized') {
    return 'unauthorized'
  }
  return 'unknown-error'
})
``` 

**Type Safe:**

```typescript
async function getUserId(): SoundPromise<number, 'timeout' | 'unauthorized'> {
  const rand = Math.random()

  if (rand < 0.1) {
    return err('timeout')
  }
  if (rand < 0.2) {
    return err('unauthorized')
  }

  return ok(5)
}

const typeSafePromise = ResultAsync.fromSoundPromise(getUserId())
```