### PR TITLE
Fix #249: ResultAsync.fromPromise/fromSafePromise accepts PromiseLike interface

### DIFF
--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -8,12 +8,14 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
     this._promise = res
   }
 
+  static fromSafePromise<T, E>(promise: PromiseLike<T>): ResultAsync<T, E>;
   static fromSafePromise<T, E>(promise: Promise<T>): ResultAsync<T, E> {
     const newPromise = promise.then((value: T) => new Ok<T, E>(value))
 
     return new ResultAsync(newPromise)
   }
 
+  static fromPromise<T, E>(promise: PromiseLike<T>, errorFn: (e: unknown) => E): ResultAsync<T, E>;
   static fromPromise<T, E>(promise: Promise<T>, errorFn: (e: unknown) => E): ResultAsync<T, E> {
     const newPromise = promise
       .then((value: T) => new Ok<T, E>(value))

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -8,14 +8,14 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
     this._promise = res
   }
 
-  static fromSafePromise<T, E>(promise: PromiseLike<T>): ResultAsync<T, E>;
+  static fromSafePromise<T, E>(promise: PromiseLike<T>): ResultAsync<T, E>
   static fromSafePromise<T, E>(promise: Promise<T>): ResultAsync<T, E> {
     const newPromise = promise.then((value: T) => new Ok<T, E>(value))
 
     return new ResultAsync(newPromise)
   }
 
-  static fromPromise<T, E>(promise: PromiseLike<T>, errorFn: (e: unknown) => E): ResultAsync<T, E>;
+  static fromPromise<T, E>(promise: PromiseLike<T>, errorFn: (e: unknown) => E): ResultAsync<T, E>
   static fromPromise<T, E>(promise: Promise<T>, errorFn: (e: unknown) => E): ResultAsync<T, E> {
     const newPromise = promise
       .then((value: T) => new Ok<T, E>(value))


### PR DESCRIPTION
Thank you for these very useful library. One of my dependency returns `PromiseLike` objects. It was becoming a pain to cast them as `Promise` for every call. Hence, this PR.

This is a fairly simple and non-breaking change. 