### PR TITLE
Feat/split combine into sync and async ii

### DIFF
--- a/src/_internals/utils.ts
+++ b/src/_internals/utils.ts
@@ -1,23 +1,23 @@
-import { Result, ok, err } from './result'
-import { ResultAsync } from './result-async'
+import { Result, ok, err } from '../result'
+import { ResultAsync } from '../result-async'
 
 // Given a list of Results, this extracts all the different `T` types from that list
-type ExtractOkTypes<T extends readonly Result<unknown, unknown>[]> = {
+export type ExtractOkTypes<T extends readonly Result<unknown, unknown>[]> = {
   [idx in keyof T]: T[idx] extends Result<infer U, unknown> ? U : never
 }
 
 // Given a list of ResultAsyncs, this extracts all the different `T` types from that list
-type ExtractOkAsyncTypes<T extends readonly ResultAsync<unknown, unknown>[]> = {
+export type ExtractOkAsyncTypes<T extends readonly ResultAsync<unknown, unknown>[]> = {
   [idx in keyof T]: T[idx] extends ResultAsync<infer U, unknown> ? U : never
 }
 
 // Given a list of Results, this extracts all the different `E` types from that list
-type ExtractErrTypes<T extends readonly Result<unknown, unknown>[]> = {
+export type ExtractErrTypes<T extends readonly Result<unknown, unknown>[]> = {
   [idx in keyof T]: T[idx] extends Result<unknown, infer E> ? E : never
 }
 
 // Given a list of ResultAsyncs, this extracts all the different `E` types from that list
-type ExtractErrAsyncTypes<T extends readonly ResultAsync<unknown, unknown>[]> = {
+export type ExtractErrAsyncTypes<T extends readonly ResultAsync<unknown, unknown>[]> = {
   [idx in keyof T]: T[idx] extends ResultAsync<unknown, infer E> ? E : never
 }
 
@@ -32,7 +32,7 @@ const appendValueToEndOfList = <T>(value: T) => (list: T[]): T[] => [...list, va
 /**
  * Short circuits on the FIRST Err value that we find
  */
-const combineResultList = <T, E>(resultList: Result<T, E>[]): Result<T[], E> =>
+export const combineResultList = <T, E>(resultList: Result<T, E>[]): Result<T[], E> =>
   resultList.reduce(
     (acc, result) =>
       acc.isOk()
@@ -48,32 +48,29 @@ const combineResultList = <T, E>(resultList: Result<T, E>[]): Result<T[], E> =>
  * Takes a list of ResultAsync<T, E> and success if all inner results are Ok values
  * or fails if one (or more) of the inner results are Err values
  */
-const combineResultAsyncList = <T, E>(asyncResultList: ResultAsync<T, E>[]): ResultAsync<T[], E> =>
+export const combineResultAsyncList = <T, E>(
+  asyncResultList: ResultAsync<T, E>[],
+): ResultAsync<T[], E> =>
   ResultAsync.fromSafePromise(Promise.all(asyncResultList)).andThen(
     combineResultList,
   ) as ResultAsync<T[], E>
 
 export function combine<T extends readonly Result<unknown, unknown>[]>(
   resultList: T,
-): Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number]>
-
-export function combine<T extends readonly ResultAsync<unknown, unknown>[]>(
-  asyncResultList: T,
-): ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number]>
-
-// eslint-disable-next-line
-export function combine(list: any): any {
-  if (list[0] instanceof ResultAsync) {
-    return combineResultAsyncList(list)
-  } else {
-    return combineResultList(list)
-  }
+): Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number]> {
+  // eslint-disable-next-line
+  return (combineResultList(resultList as any) as any) as Result<
+    ExtractOkTypes<T>,
+    ExtractErrTypes<T>[number]
+  >
 }
 
 /**
  * Give a list of all the errors we find
  */
-const combineResultListWithAllErrors = <T, E>(resultList: Result<T, E>[]): Result<T[], E[]> =>
+export const combineResultListWithAllErrors = <T, E>(
+  resultList: Result<T, E>[],
+): Result<T[], E[]> =>
   resultList.reduce(
     (acc, result) =>
       result.isErr()
@@ -86,26 +83,9 @@ const combineResultListWithAllErrors = <T, E>(resultList: Result<T, E>[]): Resul
     ok([]) as Result<T[], E[]>,
   )
 
-const combineResultAsyncListWithAllErrors = <T, E>(
+export const combineResultAsyncListWithAllErrors = <T, E>(
   asyncResultList: ResultAsync<T, E>[],
 ): ResultAsync<T[], E[]> =>
   ResultAsync.fromSafePromise(Promise.all(asyncResultList)).andThen(
     combineResultListWithAllErrors,
   ) as ResultAsync<T[], E[]>
-
-export function combineWithAllErrors<T extends readonly Result<unknown, unknown>[]>(
-  resultList: T,
-): Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number][]>
-
-export function combineWithAllErrors<T extends readonly ResultAsync<unknown, unknown>[]>(
-  asyncResultList: T,
-): ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number][]>
-
-// eslint-disable-next-line
-export function combineWithAllErrors(list: any): any {
-  if (list[0] instanceof ResultAsync) {
-    return combineResultAsyncListWithAllErrors(list)
-  } else {
-    return combineResultListWithAllErrors(list)
-  }
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export { Result, ok, Ok, err, Err, fromThrowable } from './result'
 export { ResultAsync, okAsync, errAsync, fromPromise, fromSafePromise } from './result-async'
-export { combine, combineWithAllErrors } from './utils'

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -1,4 +1,13 @@
-import { InferOkTypes, InferErrTypes, InferAsyncOkTypes, InferAsyncErrTypes } from './utils'
+import {
+  InferOkTypes,
+  InferErrTypes,
+  InferAsyncOkTypes,
+  InferAsyncErrTypes,
+  ExtractOkAsyncTypes,
+  ExtractErrAsyncTypes,
+  combineResultAsyncList,
+  combineResultAsyncListWithAllErrors
+} from './_internals/utils'
 import { Result, Ok, Err } from './'
 
 export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
@@ -22,6 +31,27 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
       .catch((e) => new Err<T, E>(errorFn(e)))
 
     return new ResultAsync(newPromise)
+  }
+
+  static combine<T extends readonly ResultAsync<unknown, unknown>[]>(
+    // eslint-disable-next-line
+    asyncResultList: T,
+  ): ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (combineResultAsyncList(asyncResultList as any) as any) as ResultAsync<
+      ExtractOkAsyncTypes<T>,
+      ExtractErrAsyncTypes<T>[number]
+    >
+  }
+
+  static combineWithAllErrors<T extends readonly ResultAsync<unknown, unknown>[]>(
+    asyncResultList: T,
+  ): ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number][]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (combineResultAsyncListWithAllErrors(asyncResultList as any) as any) as ResultAsync<
+      ExtractOkAsyncTypes<T>,
+      ExtractErrAsyncTypes<T>[number][]
+    >
   }
 
   map<A>(f: (t: T) => A | Promise<A>): ResultAsync<A, E> {

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,12 @@
 import { ResultAsync, errAsync } from './'
-import { InferOkTypes, InferErrTypes } from './utils'
+import {
+  InferOkTypes,
+  InferErrTypes,
+  ExtractOkTypes,
+  ExtractErrTypes,
+  combineResultList,
+  combineResultListWithAllErrors,
+} from './_internals/utils'
 import { createNeverThrowError, ErrorConfig } from './_internals/error'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -25,7 +32,28 @@ export namespace Result {
       }
     }
   }
+
+  export function combine<T extends readonly Result<unknown, unknown>[]>(
+    resultList: T,
+  ): Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (combineResultList(resultList as any) as any) as Result<
+      ExtractOkTypes<T>,
+      ExtractErrTypes<T>[number]
+    >
+  }
+
+  export function combineWithAllErrors<T extends readonly Result<unknown, unknown>[]>(
+    resultList: T,
+  ): Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number][]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (combineResultListWithAllErrors(resultList as any) as any) as Result<
+      ExtractOkTypes<T>,
+      ExtractErrTypes<T>[number][]
+    >
+  }
 }
+
 export type Result<T, E> = Ok<T, E> | Err<T, E>
 
 export const ok = <T, E = never>(value: T): Ok<T, E> => new Ok(value)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,5 @@
 import { ok, err, Ok, Err, Result, ResultAsync, okAsync, errAsync, fromPromise, fromSafePromise, fromThrowable } from '../src'
 import * as td from 'testdouble'
-import { combine, combineWithAllErrors } from '../src/utils'
 
 describe('Result.Ok', () => {
   it('Creates an Ok value', () => {
@@ -367,12 +366,12 @@ describe('Result.fromThrowable', () => {
 })
 
 describe('Utils', () => {
-  describe('`combine`', () => {
+  describe('`Result.combine`', () => {
     describe('Synchronous `combine`', () => {
       it('Combines a list of results into an Ok value', () => {
         const resultList = [ok(123), ok(456), ok(789)]
 
-        const result = combine(resultList)
+        const result = Result.combine(resultList)
 
         expect(result.isOk()).toBe(true)
         expect(result._unsafeUnwrap()).toEqual([123, 456, 789])
@@ -386,7 +385,7 @@ describe('Utils', () => {
           err('ahhhhh!'),
         ]
 
-        const result = combine(resultList)
+        const result = Result.combine(resultList)
 
         expect(result.isErr()).toBe(true)
         expect(result._unsafeUnwrapErr()).toBe('boooom!')
@@ -403,7 +402,7 @@ describe('Utils', () => {
 
         type ExpecteResult = Result<[ string, number, boolean ], string | number | boolean>
 
-        const result: ExpecteResult = combine(heterogenousList)
+        const result: ExpecteResult = Result.combine(heterogenousList)
 
         expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true])
       })
@@ -421,21 +420,21 @@ describe('Utils', () => {
 
         type ExpectedResult = Result<[ string[], number[] ], boolean | string>
 
-        const result: ExpectedResult = combine(homogenousList)
+        const result: ExpectedResult = Result.combine(homogenousList)
 
         expect(result._unsafeUnwrap()).toEqual([ [ 'hello', 'world' ], [ 1, 2, 3 ]])
       })
     })
 
-    describe('Async `combine`', () => {
+    describe('`ResultAsync.combine`', () => {
       it('Combines a list of async results into an Ok value', async () => {
         const asyncResultList = [okAsync(123), okAsync(456), okAsync(789)]
 
-        const resultAsync: ResultAsync<number[], unknown> = combine(asyncResultList)
+        const resultAsync: ResultAsync<number[], unknown> = ResultAsync.combine(asyncResultList)
         
         expect(resultAsync).toBeInstanceOf(ResultAsync)
 
-        const result = await combine(asyncResultList)
+        const result = await ResultAsync.combine(asyncResultList)
 
         expect(result.isOk()).toBe(true)
         expect(result._unsafeUnwrap()).toEqual([123, 456, 789])
@@ -449,7 +448,7 @@ describe('Utils', () => {
           errAsync('ahhhhh!'),
         ]
 
-        const result = await combine(resultList)
+        const result = await ResultAsync.combine(resultList)
 
         expect(result.isErr()).toBe(true)
         expect(result._unsafeUnwrapErr()).toBe('boooom!')
@@ -472,18 +471,18 @@ describe('Utils', () => {
 
         type ExpecteResult = Result<[ string, number, boolean, number[] ], string | number | boolean>
 
-        const result: ExpecteResult = await combine(heterogenousList)
+        const result: ExpecteResult = await ResultAsync.combine(heterogenousList)
 
         expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true, [ 1, 2, 3 ]])
       })
     })
   })
-  describe('`combineWithAllErrors`', () => {
+  describe('`Result.combineWithAllErrors`', () => {
     describe('Synchronous `combineWithAllErrors`', () => {
       it('Combines a list of results into an Ok value', () => {
         const resultList = [ok(123), ok(456), ok(789)]
 
-        const result = combineWithAllErrors(resultList)
+        const result = Result.combineWithAllErrors(resultList)
 
         expect(result.isOk()).toBe(true)
         expect(result._unsafeUnwrap()).toEqual([123, 456, 789])
@@ -497,7 +496,7 @@ describe('Utils', () => {
           err('ahhhhh!'),
         ]
 
-        const result = combineWithAllErrors(resultList)
+        const result = Result.combineWithAllErrors(resultList)
 
         expect(result.isErr()).toBe(true)
         expect(result._unsafeUnwrapErr()).toEqual(['boooom!', 'ahhhhh!'])
@@ -514,7 +513,7 @@ describe('Utils', () => {
 
         type ExpecteResult = Result<[ string, number, boolean ], (string | number | boolean)[]>
 
-        const result: ExpecteResult = combineWithAllErrors(heterogenousList)
+        const result: ExpecteResult = Result.combineWithAllErrors(heterogenousList)
 
         expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true])
       })
@@ -532,16 +531,16 @@ describe('Utils', () => {
 
         type ExpectedResult = Result<[ string[], number[] ], (boolean | string)[]>
 
-        const result: ExpectedResult = combineWithAllErrors(homogenousList)
+        const result: ExpectedResult = Result.combineWithAllErrors(homogenousList)
 
         expect(result._unsafeUnwrap()).toEqual([ [ 'hello', 'world' ], [ 1, 2, 3 ]])
       })
     })
-    describe('Async `combineWithAllErrors`', () => {
+    describe('`ResultAsync.combineWithAllErrors`', () => {
       it('Combines a list of async results into an Ok value', async () => {
         const asyncResultList = [okAsync(123), okAsync(456), okAsync(789)]
 
-        const result = await combineWithAllErrors(asyncResultList)
+        const result = await ResultAsync.combineWithAllErrors(asyncResultList)
 
         expect(result.isOk()).toBe(true)
         expect(result._unsafeUnwrap()).toEqual([123, 456, 789])
@@ -555,7 +554,7 @@ describe('Utils', () => {
           errAsync('ahhhhh!'),
         ]
 
-        const result = await combineWithAllErrors(asyncResultList)
+        const result = await ResultAsync.combineWithAllErrors(asyncResultList)
 
         expect(result.isErr()).toBe(true)
         expect(result._unsafeUnwrapErr()).toEqual(['boooom!', 'ahhhhh!'])
@@ -572,13 +571,13 @@ describe('Utils', () => {
 
         type ExpecteResult = Result<[ string, number, boolean ], (string | number | boolean)[]>
 
-        const result: ExpecteResult = await combineWithAllErrors(heterogenousList)
+        const result: ExpecteResult = await ResultAsync.combineWithAllErrors(heterogenousList)
 
         expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true])
       })
     })
 
-    describe('testdouble `combine`', () => {
+    describe('testdouble `ResultAsync.combine`', () => {
       interface ITestInterface {
         getName(): string
         setName(name: string): void
@@ -588,7 +587,7 @@ describe('Utils', () => {
       it('Combines `testdouble` proxies from mocks generated via interfaces', async () => {
         const mock = td.object<ITestInterface>()
 
-        const result = await combine([okAsync(mock)] as const)
+        const result = await ResultAsync.combine([okAsync(mock)] as const)
 
         expect(result).toBeDefined()
         expect(result.isErr()).toBeFalsy()
@@ -941,3 +940,5 @@ describe('ResultAsync', () => {
     })
   })
 })
+
+


### PR DESCRIPTION
Resolves https://github.com/supermacro/neverthrow/issues/381

Introduces breaking API changes

This PR removes the `combine` and `combineWithAllErrors` exports and creates `Result.combine`, `Result.combineWithAllErrors`, `ResultAsync.combine`, `ResultAsync.combineWithAllErrors`.

The "Utilities" section of the README has been removed as it would become just references to Result and ResultAsync sections.