### PR TITLE
split combine and combineWithAllErrors into sync and async versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ For asynchronous tasks, `neverthrow` offers a `ResultAsync` class which wraps a 
     - [`ResultAsync.andThen` (method)](#resultasyncandthen-method-1)
     - [`ResultAsync.orElse` (method)](#resultasyncorelse-method)
     - [`ResultAsync.match` (method)](#resultasyncmatch-method)
+  + [Utilities](#utilities)
+    - [`fromThrowable`](#fromThrowable)
+    - [`fromPromise`](#fromPromise)
+    - [`fromSafePromise`](#fromSafePromise)
   + [Testing](#testing)
 * [A note on the Package Name](#a-note-on-the-package-name)
 
@@ -653,7 +657,22 @@ const result = Result.combineWithAllErrors(resultList)
 // result is Err(['boooom!', 'ahhhhh!'])
 ```
 
+[[⬆️  Back to top](#toc)
+---
+#### fromThrowable
+Top level export of `Result.fromThrowable`.
+Please find documentation at [Result.fromThrowable](#resultfromthrowable-static-class-method)
 [⬆️  Back to top](#toc)
+---
+#### fromPromise
+Top level export of `ResultAsync.fromPromise`.
+Please find documentation at [ResultAsync.fromPromise](#resultasyncfrompromise-static-class-method)
+[⬆️  Back to top](#toc)
+---
+#### fromSafePromise
+Top level export of `ResultAsync.fromSafePromise`.
+Please find documentation at [ResultAsync.fromSafePromise](#resultasyncfromsafepromise-static-class-method)
+[⬆️  Back to top](#toc)⬆️  Back to top](#toc)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,39 @@ const result = ResultAsync.combineWithAllErrors(resultList)
 // result is Err(['boooom!', 'ahhhhh!'])
 ```
 
+
+---
+
+#### fromThrowable
+
+Top level export of `Result.fromThrowable`.
+
+Please find documentation at [Result.fromThrowable](#resultfromthrowable-static-class-method)
+
+[⬆️  Back to top](#toc)
+
+
+---
+
+#### fromPromise
+
+Top level export of `ResultAsync.fromPromise`.
+
+Please find documentation at [ResultAsync.fromPromise](#resultasyncfrompromise-static-class-method)
+
+[⬆️  Back to top](#toc)
+
+
+---
+
+#### fromSafePromise
+
+Top level export of `ResultAsync.fromSafePromise`.
+
+Please find documentation at [ResultAsync.fromSafePromise](#resultasyncfromsafepromise-static-class-method)
+
+[⬆️  Back to top](#toc)
+
 ### Testing
 
 `Result` instances have two unsafe methods, aptly called `_unsafeUnwrap` and `_unsafeUnwrapErr` which **should only be used in a test environment**.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ For asynchronous tasks, `neverthrow` offers a `ResultAsync` class which wraps a 
     - [`Result.match` (method)](#resultmatch-method)
     - [`Result.asyncMap` (method)](#resultasyncmap-method)
     - [`Result.fromThrowable` (static class method)](#resultfromthrowable-static-class-method)
+    - [`Result.combine` (static class method)](#resultcombine-static-class-method)
+    - [`Result.combineWithAllErrors` (static class method)](#resultcombinewithallerrorsr-static-class-method)
   + [Asynchronous API (`ResultAsync`)](#asynchronous-api-resultasync)
     - [`okAsync`](#okasync)
     - [`errAsync`](#errasync)
@@ -50,12 +52,6 @@ For asynchronous tasks, `neverthrow` offers a `ResultAsync` class which wraps a 
     - [`ResultAsync.andThen` (method)](#resultasyncandthen-method-1)
     - [`ResultAsync.orElse` (method)](#resultasyncorelse-method)
     - [`ResultAsync.match` (method)](#resultasyncmatch-method)
-  + [Utilities](#utilities)
-    - [`combine`](#combine)
-    - [`combineWithAllErrors`](#combineWithAllErrors)
-    - [`fromThrowable`](#fromThrowable)
-    - [`fromPromise`](#fromPromise)
-    - [`fromSafePromise`](#fromSafePromise)
   + [Testing](#testing)
 * [A note on the Package Name](#a-note-on-the-package-name)
 
@@ -94,11 +90,10 @@ This plugin is essentially a porting of Rust's [`must-use`](https://doc.rust-lan
 - `err` convenience function to create an `Err` variant of `Result`
 - `Ok` class and type
 - `Err` class and type
-- `Result` Type as well as namespace / object from which to call [`Result.fromThrowable`](#resultfromthrowable-static-class-method)
+- `Result` Type as well as namespace / object from which to call [`Result.fromThrowable`](#resultfromthrowable-static-class-method), [Result.combine](#resultcombine-static-class-method).
 - `ResultAsync` class
 - `okAsync` convenience function to create a `ResultAsync` containing an `Ok` type `Result`
 - `errAsync` convenience function to create a `ResultAsync` containing an `Err` type `Result`
-- `combine` utility function that allows you to turn `Result<T, E>[]` into `Result<T[], E>`, or a `ResultAsync<T, E>[]` into `ResultAsync<T[], E>` (just like `Promise.all`)
 
 ```typescript
 import {
@@ -110,7 +105,6 @@ import {
   okAsync,
   errAsync,
   ResultAsync,
-  combine,
   fromThrowable,
   fromPromise,
   fromSafePromise,
@@ -570,6 +564,99 @@ const res = safeJsonParse("{");
 
 ---
 
+#### `Result.combine` (static class method)
+
+> Although Result is not an actual JS class, the way that `combine` has been implemented requires that you call `combine` as though it were a static method on `Result`. See examples below.
+
+Combine lists of `Result`s.
+
+If you're familiar with `Promise.all`, the combine function works conceptually the same.
+
+**`combine` works on both heterogeneous and homogeneous lists**. This means that you can have lists that contain different kinds of `Result`s and still be able to combine them. Note that you cannot combine lists that contain both `Result`s **and** `ResultAsync`s.
+
+The combine function takes a list of results and returns a single result. If all the results in the list are `Ok`, then the return value will be a `Ok` containing a list of all the individual `Ok` values.
+
+If just one of the results in the list is an `Err` then the combine function returns that Err value (it short circuits and returns the first Err that it finds).
+
+Formally speaking:
+
+```typescript
+// homogeneous lists
+function combine<T, E>(resultList: Result<T, E>[]): Result<T[], E>
+
+// heterogeneous lists
+function combine<T1, T2, E1, E2>(resultList: [ Result<T1, E1>, Result<T2, E2> ]): Result<[ T1, T2 ], E1 | E2>
+function combine<T1, T2, T3, E1, E2, E3> => Result<[ T1, T2, T3 ], E1 | E2 | E3>
+function combine<T1, T2, T3, T4, E1, E2, E3, E4> => Result<[ T1, T2, T3, T4 ], E1 | E2 | E3 | E4>
+// ... etc etc ad infinitum
+
+```
+
+Example:
+```typescript
+const resultList: Result<number, never>[] =
+  [ok(1), ok(2)]
+
+const combinedList: Result<number[], unknown> =
+  Result.combine(resultList)
+```
+
+Example with tuples:
+```typescript
+/** @example tuple(1, 2, 3) === [1, 2, 3] // with type [number, number, number] */
+const tuple = <T extends any[]>(...args: T): T => args
+
+const resultTuple: [Result<string, never>, Result<string, never>] =
+  tuple(ok('a'), ok('b'))
+
+const combinedTuple: Result<[string, string], unknown> =
+  Result.combine(resultTuple)
+```
+
+[⬆️  Back to top](#toc)
+
+---
+
+#### `Result.combineWithAllErrors` (static class method)
+
+> Although Result is not an actual JS class, the way that `combineWithAllErrors` has been implemented requires that you call `combineWithAllErrors` as though it were a static method on `Result`. See examples below.
+
+Like `combine` but without short-circuiting. Instead of just the first error value, you get a list of all error values of the input result list.
+
+If only some results fail, the new combined error list will only contain the error value of the failed results, meaning that there is no guarantee of the length of the new error list.
+
+Function signature:
+
+```typescript
+// homogeneous lists
+function combineWithAllErrors<T, E>(resultList: Result<T, E>[]): Result<T[], E[]>
+
+// heterogeneous lists
+function combineWithAllErrors<T1, T2, E1, E2>(resultList: [ Result<T1, E1>, Result<T2, E2> ]): Result<[ T1, T2 ], (E1 | E2)[]>
+function combineWithAllErrors<T1, T2, T3, E1, E2, E3> => Result<[ T1, T2, T3 ], (E1 | E2 | E3)[]>
+function combineWithAllErrors<T1, T2, T3, T4, E1, E2, E3, E4> => Result<[ T1, T2, T3, T4 ], (E1 | E2 | E3 | E4)[]>
+// ... etc etc ad infinitum
+```
+
+Example usage:
+
+```typescript
+const resultList: Result<number, string>[] = [
+  ok(123),
+  err('boooom!'),
+  ok(456),
+  err('ahhhhh!'),
+]
+
+const result = Result.combineWithAllErrors(resultList)
+
+// result is Err(['boooom!', 'ahhhhh!'])
+```
+
+[⬆️  Back to top](#toc)
+
+---
+
 ### Asynchronous API (`ResultAsync`)
 
 #### `okAsync`
@@ -951,15 +1038,13 @@ const resultMessage = await validateUser(user)
 
 ---
 
-### Utilities
+#### `ResultAsync.combine` (static class method)
 
-#### `combine`
-
-Combine lists of `Result`s or lists of `ResultAsync`s.
+Combine lists of `ResultAsync`s.
 
 If you're familiar with `Promise.all`, the combine function works conceptually the same.
 
-**`combine` works on both heterogeneous and homogeneous lists**. This means that you can have lists that contain different kinds of `Result`s and still be able to combine them. Note that you cannot combine lists that contain both `Result`s **and** `ResultAsync`s.
+**`combine` works on both heterogeneous and homogeneous lists**. This means that you can have lists that contain different kinds of `ResultAsync`s and still be able to combine them. Note that you cannot combine lists that contain both `Result`s **and** `ResultAsync`s.
 
 The combine function takes a list of results and returns a single result. If all the results in the list are `Ok`, then the return value will be a `Ok` containing a list of all the individual `Ok` values.
 
@@ -969,97 +1054,73 @@ Formally speaking:
 
 ```typescript
 // homogeneous lists
-function combine<T, E>(resultList: Result<T, E>[]): Result<T[], E>
+function combine<T, E>(resultList: ResultAsync<T, E>[]): ResultAsync<T[], E>
 
 // heterogeneous lists
-function combine<T1, T2, E1, E2>(resultList: [ Result<T1, E1>, Result<T2, E2> ]): Result<[ T1, T2 ], E1 | E2>
-function combine<T1, T2, T3, E1, E2, E3> => Result<[ T1, T2, T3 ], E1 | E2 | E3>
-function combine<T1, T2, T3, T4, E1, E2, E3, E4> => Result<[ T1, T2, T3, T4 ], E1 | E2 | E3 | E4>
+function combine<T1, T2, E1, E2>(resultList: [ ResultAsync<T1, E1>, ResultAsync<T2, E2> ]): ResultAsync<[ T1, T2 ], E1 | E2>
+function combine<T1, T2, T3, E1, E2, E3> => ResultAsync<[ T1, T2, T3 ], E1 | E2 | E3>
+function combine<T1, T2, T3, T4, E1, E2, E3, E4> => ResultAsync<[ T1, T2, T3, T4 ], E1 | E2 | E3 | E4>
 // ... etc etc ad infinitum
 
 ```
 
-Additionally, this same function also works for `ResultAsync`. And thanks to typescript function overloading, the types can be distinguished.
-
+Example:
 ```typescript
-function combine<T, E>(asyncResultList: ResultAsync<T, E>[]): ResultAsync<T[], E>
+const resultList: ResultAsync<number, never>[] =
+  [okAsync(1), okAsync(2)]
+
+const combinedList: ResultAsync<number[], unknown> =
+  ResultAsync.combine(resultList)
 ```
 
-[⬆️  Back to top](#toc)
+Example with tuples:
+```typescript
+/** @example tuple(1, 2, 3) === [1, 2, 3] // with type [number, number, number] */
+const tuple = <T extends any[]>(...args: T): T => args
 
+const resultTuple: [ResultAsync<string, never>, ResultAsync<string, never>] =
+  tuple(okAsync('a'), okAsync('b'))
+
+const combinedTuple: ResultAsync<[string, string], unknown> =
+  ResultAsync.combine(resultTuple)
+```
+[⬆️  Back to top](#toc)
 
 ---
 
-#### `combineWithAllErrors`
+#### `ResultAsync.combineWithAllErrors` (static class method)
 
 Like `combine` but without short-circuiting. Instead of just the first error value, you get a list of all error values of the input result list.
 
 If only some results fail, the new combined error list will only contain the error value of the failed results, meaning that there is no guarantee of the length of the new error list.
 
-Like `combine`, it works for both `Result` and `ResultAsync`.
-
 Function signature:
 
 ```typescript
 // homogeneous lists
-function combineWithAllErrors<T, E>(resultList: Result<T, E>[]): Result<T[], E[]>
+function combineWithAllErrors<T, E>(resultList: ResultAsync<T, E>[]): ResultAsync<T[], E[]>
 
 // heterogeneous lists
-function combineWithAllErrors<T1, T2, E1, E2>(resultList: [ Result<T1, E1>, Result<T2, E2> ]): Result<[ T1, T2 ], (E1 | E2)[]>
-function combineWithAllErrors<T1, T2, T3, E1, E2, E3> => Result<[ T1, T2, T3 ], (E1 | E2 | E3)[]>
-function combineWithAllErrors<T1, T2, T3, T4, E1, E2, E3, E4> => Result<[ T1, T2, T3, T4 ], (E1 | E2 | E3 | E4)[]>
+function combineWithAllErrors<T1, T2, E1, E2>(resultList: [ ResultAsync<T1, E1>, ResultAsync<T2, E2> ]): ResultAsync<[ T1, T2 ], (E1 | E2)[]>
+function combineWithAllErrors<T1, T2, T3, E1, E2, E3> => ResultAsync<[ T1, T2, T3 ], (E1 | E2 | E3)[]>
+function combineWithAllErrors<T1, T2, T3, T4, E1, E2, E3, E4> => ResultAsync<[ T1, T2, T3, T4 ], (E1 | E2 | E3 | E4)[]>
 // ... etc etc ad infinitum
 ```
 
 Example usage:
 
 ```typescript
-const resultList: Result<number, string>[] = [
-  ok(123),
-  err('boooom!'),
-  ok(456),
-  err('ahhhhh!'),
+const resultList: ResultAsync<number, string>[] = [
+  okAsync(123),
+  errAsync('boooom!'),
+  okAsync(456),
+  errAsync('ahhhhh!'),
 ]
 
-const result = combineWithAllErrors(resultList)
+const result = ResultAsync.combineWithAllErrors(resultList)
 
 // result is Err(['boooom!', 'ahhhhh!'])
 ```
-
-[⬆️  Back to top](#toc)
-
-
----
-
-#### fromThrowable
-
-Top level export of `Result.fromThrowable`.
-
-Please find documentation at [Result.fromThrowable](#resultfromthrowable-static-class-method)
-
-[⬆️  Back to top](#toc)
-
-
----
-
-#### fromPromise
-
-Top level export of `ResultAsync.fromPromise`.
-
-Please find documentation at [ResultAsync.fromPromise](#resultasyncfrompromise-static-class-method)
-
-[⬆️  Back to top](#toc)
-
-
----
-
-#### fromSafePromise
-
-Top level export of `ResultAsync.fromSafePromise`.
-
-Please find documentation at [ResultAsync.fromSafePromise](#resultasyncfromsafepromise-static-class-method)
-
-[⬆️  Back to top](#toc)
 
 ### Testing
 

--- a/src/_internals/error.ts
+++ b/src/_internals/error.ts
@@ -8,13 +8,27 @@ const defaultErrorConfig: ErrorConfig = {
   withStackTrace: false,
 }
 
+interface NeverThrowError<T, E> {
+  data:
+    | {
+        type: string
+        value: T
+      }
+    | {
+        type: string
+        value: E
+      }
+  message: string
+  stack: string | undefined
+}
+
 // Custom error object
 // Context / discussion: https://github.com/supermacro/neverthrow/pull/215
 export const createNeverThrowError = <T, E>(
   message: string,
   result: Result<T, E>,
   config: ErrorConfig = defaultErrorConfig,
-) => {
+): NeverThrowError<T, E> => {
   const data = result.isOk()
     ? { type: 'Ok', value: result.value }
     : { type: 'Err', value: result.error }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export { Result, ok, Ok, err, Err, fromThrowable } from './result'
 export { ResultAsync, okAsync, errAsync, fromPromise, fromSafePromise } from './result-async'
-export { combine, combineWithAllErrors } from './utils'

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -1,4 +1,13 @@
-import { InferOkTypes, InferErrTypes, InferAsyncOkTypes, InferAsyncErrTypes } from './utils'
+import {
+  InferOkTypes,
+  InferErrTypes,
+  InferAsyncOkTypes,
+  InferAsyncErrTypes,
+  ExtractOkAsyncTypes,
+  ExtractErrAsyncTypes,
+  combineResultAsyncList,
+  combineResultAsyncListWithAllErrors,
+} from './_internals/utils'
 import { Result, Ok, Err } from './'
 
 export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
@@ -22,6 +31,24 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
       .catch((e) => new Err<T, E>(errorFn(e)))
 
     return new ResultAsync(newPromise)
+  }
+
+  static combine<T extends readonly ResultAsync<unknown, unknown>[]>(
+    asyncResultList: T,
+  ): ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number]> {
+    return combineResultAsyncList(asyncResultList) as ResultAsync<
+      ExtractOkAsyncTypes<T>,
+      ExtractErrAsyncTypes<T>[number]
+    >
+  }
+
+  static combineWithAllErrors<T extends readonly ResultAsync<unknown, unknown>[]>(
+    asyncResultList: T,
+  ): ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number][]> {
+    return combineResultAsyncListWithAllErrors(asyncResultList) as ResultAsync<
+      ExtractOkAsyncTypes<T>,
+      ExtractErrAsyncTypes<T>[number][]
+    >
   }
 
   map<A>(f: (t: T) => A | Promise<A>): ResultAsync<A, E> {

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,5 +1,12 @@
 import { ResultAsync, errAsync } from './'
-import { InferOkTypes, InferErrTypes } from './utils'
+import {
+  InferOkTypes,
+  InferErrTypes,
+  ExtractOkTypes,
+  ExtractErrTypes,
+  combineResultList,
+  combineResultListWithAllErrors,
+} from './_internals/utils'
 import { createNeverThrowError, ErrorConfig } from './_internals/error'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -25,7 +32,23 @@ export namespace Result {
       }
     }
   }
+
+  export function combine<T extends readonly Result<unknown, unknown>[]>(
+    resultList: T,
+  ): Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number]> {
+    return combineResultList(resultList) as Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number]>
+  }
+
+  export function combineWithAllErrors<T extends readonly Result<unknown, unknown>[]>(
+    resultList: T,
+  ): Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number][]> {
+    return combineResultListWithAllErrors(resultList) as Result<
+      ExtractOkTypes<T>,
+      ExtractErrTypes<T>[number][]
+    >
+  }
 }
+
 export type Result<T, E> = Ok<T, E> | Err<T, E>
 
 export const ok = <T, E = never>(value: T): Ok<T, E> => new Ok(value)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,5 @@
 import { ok, err, Ok, Err, Result, ResultAsync, okAsync, errAsync, fromPromise, fromSafePromise, fromThrowable } from '../src'
 import * as td from 'testdouble'
-import { combine, combineWithAllErrors } from '../src/utils'
 
 describe('Result.Ok', () => {
   it('Creates an Ok value', () => {
@@ -367,12 +366,12 @@ describe('Result.fromThrowable', () => {
 })
 
 describe('Utils', () => {
-  describe('`combine`', () => {
+  describe('`Result.combine`', () => {
     describe('Synchronous `combine`', () => {
       it('Combines a list of results into an Ok value', () => {
         const resultList = [ok(123), ok(456), ok(789)]
 
-        const result = combine(resultList)
+        const result = Result.combine(resultList)
 
         expect(result.isOk()).toBe(true)
         expect(result._unsafeUnwrap()).toEqual([123, 456, 789])
@@ -386,7 +385,7 @@ describe('Utils', () => {
           err('ahhhhh!'),
         ]
 
-        const result = combine(resultList)
+        const result = Result.combine(resultList)
 
         expect(result.isErr()).toBe(true)
         expect(result._unsafeUnwrapErr()).toBe('boooom!')
@@ -403,7 +402,7 @@ describe('Utils', () => {
 
         type ExpecteResult = Result<[ string, number, boolean ], string | number | boolean>
 
-        const result: ExpecteResult = combine(heterogenousList)
+        const result: ExpecteResult = Result.combine(heterogenousList)
 
         expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true])
       })
@@ -421,21 +420,21 @@ describe('Utils', () => {
 
         type ExpectedResult = Result<[ string[], number[] ], boolean | string>
 
-        const result: ExpectedResult = combine(homogenousList)
+        const result: ExpectedResult = Result.combine(homogenousList)
 
         expect(result._unsafeUnwrap()).toEqual([ [ 'hello', 'world' ], [ 1, 2, 3 ]])
       })
     })
 
-    describe('Async `combine`', () => {
+    describe('`ResultAsync.combine`', () => {
       it('Combines a list of async results into an Ok value', async () => {
         const asyncResultList = [okAsync(123), okAsync(456), okAsync(789)]
 
-        const resultAsync: ResultAsync<number[], unknown> = combine(asyncResultList)
+        const resultAsync: ResultAsync<number[], unknown> = ResultAsync.combine(asyncResultList)
         
         expect(resultAsync).toBeInstanceOf(ResultAsync)
 
-        const result = await combine(asyncResultList)
+        const result = await ResultAsync.combine(asyncResultList)
 
         expect(result.isOk()).toBe(true)
         expect(result._unsafeUnwrap()).toEqual([123, 456, 789])
@@ -449,7 +448,7 @@ describe('Utils', () => {
           errAsync('ahhhhh!'),
         ]
 
-        const result = await combine(resultList)
+        const result = await ResultAsync.combine(resultList)
 
         expect(result.isErr()).toBe(true)
         expect(result._unsafeUnwrapErr()).toBe('boooom!')
@@ -472,18 +471,18 @@ describe('Utils', () => {
 
         type ExpecteResult = Result<[ string, number, boolean, number[] ], string | number | boolean>
 
-        const result: ExpecteResult = await combine(heterogenousList)
+        const result: ExpecteResult = await ResultAsync.combine(heterogenousList)
 
         expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true, [ 1, 2, 3 ]])
       })
     })
   })
-  describe('`combineWithAllErrors`', () => {
+  describe('`Result.combineWithAllErrors`', () => {
     describe('Synchronous `combineWithAllErrors`', () => {
       it('Combines a list of results into an Ok value', () => {
         const resultList = [ok(123), ok(456), ok(789)]
 
-        const result = combineWithAllErrors(resultList)
+        const result = Result.combineWithAllErrors(resultList)
 
         expect(result.isOk()).toBe(true)
         expect(result._unsafeUnwrap()).toEqual([123, 456, 789])
@@ -497,7 +496,7 @@ describe('Utils', () => {
           err('ahhhhh!'),
         ]
 
-        const result = combineWithAllErrors(resultList)
+        const result = Result.combineWithAllErrors(resultList)
 
         expect(result.isErr()).toBe(true)
         expect(result._unsafeUnwrapErr()).toEqual(['boooom!', 'ahhhhh!'])
@@ -514,7 +513,7 @@ describe('Utils', () => {
 
         type ExpecteResult = Result<[ string, number, boolean ], (string | number | boolean)[]>
 
-        const result: ExpecteResult = combineWithAllErrors(heterogenousList)
+        const result: ExpecteResult = Result.combineWithAllErrors(heterogenousList)
 
         expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true])
       })
@@ -532,16 +531,16 @@ describe('Utils', () => {
 
         type ExpectedResult = Result<[ string[], number[] ], (boolean | string)[]>
 
-        const result: ExpectedResult = combineWithAllErrors(homogenousList)
+        const result: ExpectedResult = Result.combineWithAllErrors(homogenousList)
 
         expect(result._unsafeUnwrap()).toEqual([ [ 'hello', 'world' ], [ 1, 2, 3 ]])
       })
     })
-    describe('Async `combineWithAllErrors`', () => {
+    describe('`ResultAsync.combineWithAllErrors`', () => {
       it('Combines a list of async results into an Ok value', async () => {
         const asyncResultList = [okAsync(123), okAsync(456), okAsync(789)]
 
-        const result = await combineWithAllErrors(asyncResultList)
+        const result = await ResultAsync.combineWithAllErrors(asyncResultList)
 
         expect(result.isOk()).toBe(true)
         expect(result._unsafeUnwrap()).toEqual([123, 456, 789])
@@ -555,7 +554,7 @@ describe('Utils', () => {
           errAsync('ahhhhh!'),
         ]
 
-        const result = await combineWithAllErrors(asyncResultList)
+        const result = await ResultAsync.combineWithAllErrors(asyncResultList)
 
         expect(result.isErr()).toBe(true)
         expect(result._unsafeUnwrapErr()).toEqual(['boooom!', 'ahhhhh!'])
@@ -572,13 +571,13 @@ describe('Utils', () => {
 
         type ExpecteResult = Result<[ string, number, boolean ], (string | number | boolean)[]>
 
-        const result: ExpecteResult = await combineWithAllErrors(heterogenousList)
+        const result: ExpecteResult = await ResultAsync.combineWithAllErrors(heterogenousList)
 
         expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true])
       })
     })
 
-    describe('testdouble `combine`', () => {
+    describe('testdouble `ResultAsync.combine`', () => {
       interface ITestInterface {
         getName(): string
         setName(name: string): void
@@ -588,7 +587,7 @@ describe('Utils', () => {
       it('Combines `testdouble` proxies from mocks generated via interfaces', async () => {
         const mock = td.object<ITestInterface>()
 
-        const result = await combine([okAsync(mock)] as const)
+        const result = await ResultAsync.combine([okAsync(mock)] as const)
 
         expect(result).toBeDefined()
         expect(result.isErr()).toBeFalsy()


### PR DESCRIPTION
Resolves https://github.com/supermacro/neverthrow/issues/381

This PR supersedes https://github.com/supermacro/neverthrow/pull/404

Introduces breaking API changes

This PR removes the `combine` and `combineWithAllErrors` exports and creates `Result.combine`, `Result.combineWithAllErrors`, `ResultAsync.combine`, `ResultAsync.combineWithAllErrors`.

The "Utilities" section of the README has been removed as it would become just references to Result and ResultAsync sections.