### PR TITLE
Provides the types for `combine` and `combineWithAllErrors`, solves #226

### DIFF
--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -153,7 +153,10 @@ export const errAsync = <T = never, E = unknown>(err: E): ResultAsync<T, E> =>
 export const fromPromise = ResultAsync.fromPromise
 export const fromSafePromise = ResultAsync.fromSafePromise
 
+// Combines the array of async results into one result.
 export type CombineResultAsyncs<T> = TraverseAsync<UnwrapAsync<T>>
+
+// Combines the array of async results into one result with all errors.
 export type CombineResultsWithAllErrorsArrayAsync<T> = TraverseWithAllErrorsAsync<UnwrapAsync<T>>
 
 // Unwraps the inner `Result` from a `ResultAsync` for all elements.

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -1,14 +1,21 @@
+import type {
+  Combine,
+  Dedup,
+  EmptyArrayToNever,
+  IsLiteralArray,
+  MemberListOf,
+  MembersToUnion,
+} from './result'
+
+import { Err, Ok, Result } from './'
 import {
-  InferOkTypes,
-  InferErrTypes,
-  InferAsyncOkTypes,
-  InferAsyncErrTypes,
-  ExtractOkAsyncTypes,
-  ExtractErrAsyncTypes,
   combineResultAsyncList,
   combineResultAsyncListWithAllErrors,
+  InferAsyncErrTypes,
+  InferAsyncOkTypes,
+  InferErrTypes,
+  InferOkTypes,
 } from './_internals/utils'
-import { Result, Ok, Err } from './'
 
 export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
   private _promise: Promise<Result<T, E>>
@@ -33,22 +40,30 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
     return new ResultAsync(newPromise)
   }
 
+  static combine<
+    T extends readonly [ResultAsync<unknown, unknown>, ...ResultAsync<unknown, unknown>[]]
+  >(asyncResultList: T): CombineResultAsyncs<T>
   static combine<T extends readonly ResultAsync<unknown, unknown>[]>(
     asyncResultList: T,
-  ): ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number]> {
-    return combineResultAsyncList(asyncResultList) as ResultAsync<
-      ExtractOkAsyncTypes<T>,
-      ExtractErrAsyncTypes<T>[number]
-    >
+  ): CombineResultAsyncs<T>
+  static combine<T extends readonly ResultAsync<unknown, unknown>[]>(
+    asyncResultList: T,
+  ): CombineResultAsyncs<T> {
+    return (combineResultAsyncList(asyncResultList) as unknown) as CombineResultAsyncs<T>
   }
 
+  static combineWithAllErrors<
+    T extends readonly [ResultAsync<unknown, unknown>, ...ResultAsync<unknown, unknown>[]]
+  >(asyncResultList: T): CombineResultsWithAllErrorsArrayAsync<T>
   static combineWithAllErrors<T extends readonly ResultAsync<unknown, unknown>[]>(
     asyncResultList: T,
-  ): ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number][]> {
-    return combineResultAsyncListWithAllErrors(asyncResultList) as ResultAsync<
-      ExtractOkAsyncTypes<T>,
-      ExtractErrAsyncTypes<T>[number][]
-    >
+  ): CombineResultsWithAllErrorsArrayAsync<T>
+  static combineWithAllErrors<T extends readonly ResultAsync<unknown, unknown>[]>(
+    asyncResultList: T,
+  ): CombineResultsWithAllErrorsArrayAsync<T> {
+    return combineResultAsyncListWithAllErrors(
+      asyncResultList,
+    ) as CombineResultsWithAllErrorsArrayAsync<T>
   }
 
   map<A>(f: (t: T) => A | Promise<A>): ResultAsync<A, E> {
@@ -137,3 +152,77 @@ export const errAsync = <T = never, E = unknown>(err: E): ResultAsync<T, E> =>
 
 export const fromPromise = ResultAsync.fromPromise
 export const fromSafePromise = ResultAsync.fromSafePromise
+
+export type CombineResultAsyncs<T> = TraverseAsync<UnwrapAsync<T>>
+export type CombineResultsWithAllErrorsArrayAsync<T> = TraverseWithAllErrorsAsync<UnwrapAsync<T>>
+
+// Unwraps the inner `Result` from a `ResultAsync` for all elements.
+type UnwrapAsync<T> = IsLiteralArray<T> extends 1
+  ? Writable<T> extends [infer H, ...infer Rest]
+    ? H extends PromiseLike<infer HI>
+      ? HI extends Result<unknown, unknown>
+        ? [Dedup<HI>, ...UnwrapAsync<Rest>]
+        : never
+      : never
+    : []
+  : // If we got something too general such as ResultAsync<X, Y>[] then we
+  // simply need to map it to ResultAsync<X[], Y[]>. Yet `ResultAsync`
+  // itself is a union therefore it would be enough to cast it to Ok.
+  T extends Array<infer A>
+  ? A extends PromiseLike<infer HI>
+    ? HI extends Result<infer L, infer R>
+      ? Ok<L, R>[]
+      : never
+    : never
+  : never
+
+// Traverse through the tuples of the async results and create one
+// `ResultAsync` where the collected tuples are merged.
+type TraverseAsync<T, Depth extends number = 5> = IsLiteralArray<T> extends 1
+  ? Combine<T, Depth> extends [infer Oks, infer Errs]
+    ? ResultAsync<EmptyArrayToNever<Oks>, MembersToUnion<Errs>>
+    : never
+  : // The following check is important if we somehow reach to the point of
+  // checking something similar to ResultAsync<X, Y>[]. In this case we don't
+  // know the length of the elements, therefore we need to traverse the X and Y
+  // in a way that the result should contain X[] and Y[].
+  T extends Array<infer I>
+  ? // The MemberListOf<I> here is to include all possible types. Therefore
+    // if we face (ResultAsync<X, Y> | ResultAsync<A, B>)[] this type should
+    // handle the case.
+    Combine<MemberListOf<I>, Depth> extends [infer Oks, infer Errs]
+    ? // The following `extends unknown[]` checks are just to satisfy the TS.
+      // we already expect them to be an array.
+      Oks extends unknown[]
+      ? Errs extends unknown[]
+        ? ResultAsync<EmptyArrayToNever<Oks[number][]>, MembersToUnion<Errs[number][]>>
+        : ResultAsync<EmptyArrayToNever<Oks[number][]>, Errs>
+      : // The rest of the conditions are to satisfy the TS and support
+      // the edge cases which are not really expected to happen.
+      Errs extends unknown[]
+      ? ResultAsync<Oks, MembersToUnion<Errs[number][]>>
+      : ResultAsync<Oks, Errs>
+    : never
+  : never
+
+// This type is similar to the `TraverseAsync` while the errors are also
+// collected in order. For the checks/conditions made here, see that type
+// for the documentation.
+type TraverseWithAllErrorsAsync<T, Depth extends number = 5> = IsLiteralArray<T> extends 1
+  ? Combine<T, Depth> extends [infer Oks, infer Errs]
+    ? ResultAsync<EmptyArrayToNever<Oks>, EmptyArrayToNever<Errs>>
+    : never
+  : Writable<T> extends Array<infer I>
+  ? Combine<MemberListOf<I>, Depth> extends [infer Oks, infer Errs]
+    ? Oks extends unknown[]
+      ? Errs extends unknown[]
+        ? ResultAsync<EmptyArrayToNever<Oks[number][]>, EmptyArrayToNever<Errs[number][]>>
+        : ResultAsync<EmptyArrayToNever<Oks[number][]>, Errs>
+      : Errs extends unknown[]
+      ? ResultAsync<Oks, EmptyArrayToNever<Errs[number][]>>
+      : ResultAsync<Oks, Errs>
+    : never
+  : never
+
+// Converts a reaodnly array into a writable array
+type Writable<T> = T extends ReadonlyArray<unknown> ? [...T] : T

--- a/src/result.ts
+++ b/src/result.ts
@@ -308,149 +308,160 @@ export const fromThrowable = Result.fromThrowable
 
 // Given a union, this extracts the intersection of the unions by casting it
 // to a parameter of a function and then inferring from it.
-type IntersectOf<U extends any>
-  = (U extends unknown ? (k: U) => void : never) extends ((k: infer I) => void) ? I : never
+type IntersectOf<U extends unknown> = (U extends unknown ? (k: U) => void : never) extends (
+  k: infer I,
+) => void
+  ? I
+  : never
 
 // Given a union, this extracts the last possible value.
-type Last<U extends any>
-  = IntersectOf<U extends unknown ? (x: U) => void : never> extends (x: infer P) => void ? P : never
+type Last<U extends unknown> = IntersectOf<U extends unknown ? (x: U) => void : never> extends (
+  x: infer P,
+) => void
+  ? P
+  : never
 
 /// Given a union and a member, this excludes the member.
-type ExcludeUnionItem<U extends any, M extends any> = U extends M ? never : U
+type ExcludeUnionItem<U extends unknown, M extends unknown> = U extends M ? never : U
 
 // Given two types, this checks whether the A1 is extending the A2, including
 // the `never` type in calculation. If A1 is `never`, then this will be `0`.
-type IsExtending<A1 extends any, A2 extends any>
-  = [ A1 ] extends [ never ] ? 0 : A1 extends A2 ? 1 : 0
+type IsExtending<A1 extends unknown, A2 extends unknown> = [A1] extends [never]
+  ? 0
+  : A1 extends A2
+  ? 1
+  : 0
 
 // Given an array and a type, this extends the array by appending the `A`.
-type Append<L extends ReadonlyArray<any>, A extends any> = [
-  ...L,
-  A,
-]
+type Append<L extends ReadonlyArray<unknown>, A extends unknown> = [...L, A]
 
 // Given a union, this gives the array of the union members.
-type MemberListOf<
-  Union,
-  MemberList extends ReadonlyArray<any> = [],
-  LastU = Last<Union>
-  > = {
-    0: MemberListOf<ExcludeUnionItem<Union, LastU>, Append<MemberList, LastU>>
-    1: MemberList
-  }[ IsExtending<[ Union ], [ never ]> ]
+type MemberListOf<Union, MemberList extends ReadonlyArray<unknown> = [], LastU = Last<Union>> = {
+  0: MemberListOf<ExcludeUnionItem<Union, LastU>, Append<MemberList, LastU>>
+  1: MemberList
+}[IsExtending<[Union], [never]>]
 
 // This is a helper type to prevent infinite recursion in typing rules.
 //
 // Use this with your `depth` variable in your types.
 type Prev = [
-  never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-  11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...0[]
+  never,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  ...0[]
 ]
 
 // Combines the both sides of the array of the results into a tuple of the
 // union of the ok types and the union of the err types.
 //
 // T     - The array of the results
-// Oks   - The initial `Ok` type values 
+// Oks   - The initial `Ok` type values
 // Errs  - The initial `Err` type values
 // Depth - The maximum depth.
-type Combine<
-  T,
-  Oks extends any[] = [],
-  Errs extends any[] = [],
-  Depth extends number = 5
-  >
-  =
+type Combine<T, Oks extends unknown[] = [], Errs extends unknown[] = [], Depth extends number = 5> =
   // If we have reached to the maximum depth, return unknown for both sides
-  [ Depth ] extends [ never ] ? Result<unknown, unknown>
-
-  // Otherwise test whether T is the list of possible values
-  : T extends [ infer H, ...infer Rest ] ? (
-    // And test whether the head of the list is a result
-    H extends Result<infer L, infer R> ? (
-      // Continue combining...
-      Combine<
-        // the rest of the elements
-        Rest,
-
-        // excluding the `unknown` type variables for `Ok` results
-        [ unknown ] extends [ L ] ? Oks : [ L, ...Oks ],
-
-        // excluding the `unknown` type variables for `Err` results
-        [ unknown ] extends [ R ] ? Errs : [ R, ...Errs ],
-
-        // and one less of the current depth
-        Prev[ Depth ]
-      >
-    ) : never // Impossible
-  ) : [ Oks, Errs ] // the results combined
+  [Depth] extends [never]
+    ? Result<unknown, unknown>
+    : // Otherwise test whether T is the list of possible values
+    T extends [infer H, ...infer Rest]
+    ? // And test whether the head of the list is a result
+      H extends Result<infer L, infer R>
+      ? // Continue combining...
+        Combine<
+          // the rest of the elements
+          Rest,
+          // excluding the `unknown` type variables for `Ok` results
+          [unknown] extends [L] ? Oks : [L, ...Oks],
+          // excluding the `unknown` type variables for `Err` results
+          [unknown] extends [R] ? Errs : [R, ...Errs],
+          // and one less of the current depth
+          Prev[Depth]
+        >
+      : never // Impossible
+    : [Oks, Errs] // the results combined
 
 // Reverses the given array
-type Reverse<A>
-  = A extends [ infer H, ...infer R ] ? (
-    [ ...Reverse<R>, H ]
-  ) : A
+type Reverse<A> = A extends [infer H, ...infer R] ? [...Reverse<R>, H] : A
 
 // Deduplicates the result, as the result type is a union of Err and Ok types.
-type Dedup<T>
-  = T extends Result<infer RL, infer RR>
-  ? Ok<RL, RR> : T
+type Dedup<T> = T extends Result<infer RL, infer RR> ? Ok<RL, RR> : T
 
 // Converts an empty array to never.
-type EmptyArrayToNever<T>
-  = T extends [] ? never : T
+type EmptyArrayToNever<T> = T extends [] ? never : T
 
 // Gets the member type of the array or never.
-type MembersToUnion<T>
-  = T extends any[] ? T[ number ] : never
+type MembersToUnion<T> = T extends unknown[] ? T[number] : never
 
 // Checks if the given type is a literal array.
-type IsLiteralArray<T>
-  = T extends { length: infer L } ? (
-    L extends number ? (
-      number extends L ? 0 : 1
-    ) : 0
-  ) : 0
+type IsLiteralArray<T> = T extends { length: infer L }
+  ? L extends number
+    ? number extends L
+      ? 0
+      : 1
+    : 0
+  : 0
 
 // Traverses an array of results and returns a single result containing
 // the oks and errs union-ed/combined.
 type Traverse<
   T,
-  Oks extends any[] = [],
-  Errs extends any[] = [],
+  Oks extends unknown[] = [],
+  Errs extends unknown[] = [],
   Depth extends number = 5
-  >
-  = Combine<T, Oks, Errs, Depth> extends [ infer Oks, infer Errs ] ? (
-    Result<EmptyArrayToNever<Oks>, Errs extends any[] ? Errs[ number ] : never>
-  ) : never
+> = Combine<T, Oks, Errs, Depth> extends [infer Oks, infer Errs]
+  ? Result<EmptyArrayToNever<Oks>, Errs extends unknown[] ? Errs[number] : never>
+  : never
 
 // Traverses an array of results and returns a single result containing
 // the oks combined and the array of errors combined.
 type TraverseWithAllErrors<
   T,
-  Oks extends any[] = [],
-  Errs extends any[] = [],
+  Oks extends unknown[] = [],
+  Errs extends unknown[] = [],
   Depth extends number = 5
-  >
-  = Combine<T, Oks, Errs, Depth> extends [ infer Oks, infer Errs ] ? (
-    Result<EmptyArrayToNever<Oks>, EmptyArrayToNever<MembersToUnion<Errs>>[]>
-  ) : never
+> = Combine<T, Oks, Errs, Depth> extends [infer Oks, infer Errs]
+  ? Result<EmptyArrayToNever<Oks>, EmptyArrayToNever<MembersToUnion<Errs>>[]>
+  : never
 
 // Combines the array of results into one result.
-export type CombineResults<T extends readonly Result<unknown, unknown>[]>
-  = T extends ReadonlyArray<infer U> ? (
-    Traverse<MemberListOf<Dedup<U>>> extends Result<infer L, infer R> ? (
-      IsLiteralArray<T> extends 1 ? Result<L, R> : Result<Reverse<L>, R>
-    ) : never
-  ) : never
-
+export type CombineResults<T extends readonly Result<unknown, unknown>[]> = T extends ReadonlyArray<
+  infer U
+>
+  ? Traverse<MemberListOf<Dedup<U>>> extends Result<infer L, infer R>
+    ? IsLiteralArray<T> extends 1
+      ? Result<L, R>
+      : Result<Reverse<L>, R>
+    : never
+  : never
 
 // Combines the array of results into one result with all errors.
-export type CombineResultsWithAllErrorsArray<T extends readonly Result<unknown, unknown>[]>
-  = T extends ReadonlyArray<infer U> ? (
-    TraverseWithAllErrors<MemberListOf<Dedup<U>>> extends Result<infer L, infer R> ? (
-      IsLiteralArray<T> extends 1 ? Result<L, R> : Result<Reverse<L>, R>
-    ) : never
-  ) : never
+export type CombineResultsWithAllErrorsArray<
+  T extends readonly Result<unknown, unknown>[]
+> = T extends ReadonlyArray<infer U>
+  ? TraverseWithAllErrors<MemberListOf<Dedup<U>>> extends Result<infer L, infer R>
+    ? IsLiteralArray<T> extends 1
+      ? Result<L, R>
+      : Result<Reverse<L>, R>
+    : never
+  : never
 
 //#endregion

--- a/src/result.ts
+++ b/src/result.ts
@@ -423,11 +423,19 @@ export type MemberListOf<T> = (
   : []
 
 // Converts an empty array to never.
-export type EmptyArrayToNever<T> = T extends []
+//
+// The second type parameter here will affect how to behave to `never[]`s.
+// If a precise type is required, pass `1` here so that it will resolve
+// a literal array such as `[ never, never ]`. Otherwise, set `0` or the default
+// type value will cause this to resolve the arrays containing only `never`
+// items as `never` only.
+export type EmptyArrayToNever<T, NeverArrayToNever extends number = 0> = T extends []
   ? never
-  : T extends [never, ...infer Rest]
-  ? [EmptyArrayToNever<Rest>] extends [never]
-    ? never
+  : NeverArrayToNever extends 1
+  ? T extends [never, ...infer Rest]
+    ? [EmptyArrayToNever<Rest>] extends [never]
+      ? never
+      : T
     : T
   : T
 
@@ -451,7 +459,7 @@ export type IsLiteralArray<T> = T extends { length: infer L }
 // Traverses an array of results and returns a single result containing
 // the oks and errs union-ed/combined.
 type Traverse<T, Depth extends number = 5> = Combine<T, Depth> extends [infer Oks, infer Errs]
-  ? Result<EmptyArrayToNever<Oks>, MembersToUnion<Errs>>
+  ? Result<EmptyArrayToNever<Oks, 1>, MembersToUnion<Errs>>
   : never
 
 // Traverses an array of results and returns a single result containing

--- a/src/result.ts
+++ b/src/result.ts
@@ -403,9 +403,6 @@ type Combine<T, Depth extends number = 5> = Transpose<CollectResults<T>, [], Dep
   ? [UnknownMembersToNever<L>, UnknownMembersToNever<R>]
   : never
 
-// Reverses the given array
-type Reverse<A> = A extends [infer H, ...infer R] ? [...Reverse<R>, H] : A
-
 // Deduplicates the result, as the result type is a union of Err and Ok types.
 type Dedup<T> = T extends Result<infer RL, infer RR>
   ? [unknown] extends [RL]
@@ -481,9 +478,7 @@ export type CombineResultsWithAllErrorsArray<
   ? IsLiteralArray<T> extends 1
     ? TraverseWithAllErrors<T>
     : TraverseWithAllErrors<MemberListOf<Dedup<U>>> extends Result<infer L, infer R>
-    ? IsLiteralArray<T> extends 1
-      ? Result<EmptyArrayToNever<L>, EmptyArrayToNever<R>>
-      : Result<Reverse<L>, R>
+    ? Result<EmptyArrayToNever<L>, EmptyArrayToNever<R>>
     : never
   : never
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -63,8 +63,6 @@ export const ok = <T, E = never>(value: T): Ok<T, E> => new Ok(value)
 export const err = <T = never, E = unknown>(err: E): Err<T, E> => new Err(err)
 
 interface IResult<T, E> {
-  readonly _tag: 'Ok' | 'Err'
-
   /**
    * Used to check if a `Result` is an `OK`
    *
@@ -191,8 +189,6 @@ interface IResult<T, E> {
 }
 
 export class Ok<T, E> implements IResult<T, E> {
-  readonly _tag = 'Ok'
-
   constructor(readonly value: T) {}
 
   isOk(): this is Ok<T, E> {
@@ -256,8 +252,6 @@ export class Ok<T, E> implements IResult<T, E> {
 }
 
 export class Err<T, E> implements IResult<T, E> {
-  readonly _tag = 'Err'
-
   constructor(readonly error: E) {}
 
   isOk(): this is Ok<T, E> {

--- a/src/result.ts
+++ b/src/result.ts
@@ -376,10 +376,11 @@ type CollectResults<T, Collected extends unknown[] = [], Depth extends number = 
 // A          - The array source
 // Transposed - The collected transposed array
 // Depth      - The maximum depth.
-type Transpose<A, Transposed extends unknown[][] = [], Depth extends number = 10> = A extends [
-  infer T,
-  ...infer Rest
-]
+export type Transpose<
+  A,
+  Transposed extends unknown[][] = [],
+  Depth extends number = 10
+> = A extends [infer T, ...infer Rest]
   ? T extends [infer L, infer R]
     ? Transposed extends [infer PL, infer PR]
       ? PL extends unknown[]

--- a/src/result.ts
+++ b/src/result.ts
@@ -397,7 +397,7 @@ export type Transpose<
 //
 // T     - The array of the results
 // Depth - The maximum depth.
-type Combine<T, Depth extends number = 5> = Transpose<CollectResults<T>, [], Depth> extends [
+export type Combine<T, Depth extends number = 5> = Transpose<CollectResults<T>, [], Depth> extends [
   infer L,
   infer R,
 ]
@@ -405,14 +405,14 @@ type Combine<T, Depth extends number = 5> = Transpose<CollectResults<T>, [], Dep
   : never
 
 // Deduplicates the result, as the result type is a union of Err and Ok types.
-type Dedup<T> = T extends Result<infer RL, infer RR>
+export type Dedup<T> = T extends Result<infer RL, infer RR>
   ? [unknown] extends [RL]
     ? Err<RL, RR>
     : Ok<RL, RR>
   : T
 
 // Given a union, this gives the array of the union members.
-type MemberListOf<T> = (
+export type MemberListOf<T> = (
   (T extends unknown ? (t: T) => T : never) extends infer U
     ? (U extends unknown ? (u: U) => unknown : never) extends (v: infer V) => unknown
       ? V
@@ -437,10 +437,10 @@ type UnknownMembersToNever<T> = T extends [infer H, ...infer R]
   : T
 
 // Gets the member type of the array or never.
-type MembersToUnion<T> = T extends unknown[] ? T[number] : never
+export type MembersToUnion<T> = T extends unknown[] ? T[number] : never
 
 // Checks if the given type is a literal array.
-type IsLiteralArray<T> = T extends { length: infer L }
+export type IsLiteralArray<T> = T extends { length: infer L }
   ? L extends number
     ? number extends L
       ? 0

--- a/src/result.ts
+++ b/src/result.ts
@@ -423,12 +423,12 @@ type MemberListOf<T> = (
   : []
 
 // Converts an empty array to never.
-type EmptyArrayToNever<T> = T extends [infer H, ...infer R]
-  ? [never] extends [H]
-    ? EmptyArrayToNever<R>
-    : T
-  : T extends []
+export type EmptyArrayToNever<T> = T extends []
   ? never
+  : T extends [never, ...infer Rest]
+  ? [EmptyArrayToNever<Rest>] extends [never]
+    ? never
+    : T
   : T
 
 // Converts the `unknown` items of an array to `never`s.

--- a/src/result.ts
+++ b/src/result.ts
@@ -380,7 +380,7 @@ type Prev = [
 type Combine<T, Oks extends unknown[] = [], Errs extends unknown[] = [], Depth extends number = 5> =
   // If we have reached to the maximum depth, return unknown for both sides
   [Depth] extends [never]
-    ? Result<unknown, unknown>
+    ? [unknown[], unknown[]]
     : // Otherwise test whether T is the list of possible values
     T extends [infer H, ...infer Rest]
     ? // And test whether the head of the list is a result

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,18 @@
-import { ok, err, Ok, Err, Result, ResultAsync, okAsync, errAsync, fromPromise, fromSafePromise, fromThrowable } from '../src'
 import * as td from 'testdouble'
+
+import {
+  err,
+  Err,
+  errAsync,
+  fromPromise,
+  fromSafePromise,
+  fromThrowable,
+  ok,
+  Ok,
+  okAsync,
+  Result,
+  ResultAsync,
+} from '../src'
 
 describe('Result.Ok', () => {
   it('Creates an Ok value', () => {
@@ -430,7 +443,7 @@ describe('Utils', () => {
       it('Combines a list of async results into an Ok value', async () => {
         const asyncResultList = [okAsync(123), okAsync(456), okAsync(789)]
 
-        const resultAsync: ResultAsync<number[], unknown> = ResultAsync.combine(asyncResultList)
+        const resultAsync: ResultAsync<number[], never[]> = ResultAsync.combine(asyncResultList)
         
         expect(resultAsync).toBeInstanceOf(ResultAsync)
 
@@ -569,7 +582,7 @@ describe('Utils', () => {
           okAsync(true),
         ]
 
-        type ExpecteResult = Result<[ string, number, boolean ], (string | number | boolean)[]>
+        type ExpecteResult = Result<[ string, number, boolean ], [string, number, boolean]>
 
         const result: ExpecteResult = await ResultAsync.combineWithAllErrors(heterogenousList)
 

--- a/tests/typecheck-tests.ts
+++ b/tests/typecheck-tests.ts
@@ -4,7 +4,16 @@
  * This file is ran during CI to ensure that there aren't breaking changes with types
  */
 
-import { ok, err, okAsync, errAsync, fromSafePromise, Result, ResultAsync } from '../src'
+import {
+  err,
+  errAsync,
+  fromSafePromise,
+  ok,
+  okAsync,
+  Result,
+  ResultAsync,
+} from '../src'
+import { Transpose } from '../src/result'
 
 (function describe(_ = 'Result') {
   (function describe(_ = 'andThen') {
@@ -620,3 +629,58 @@ import { ok, err, okAsync, errAsync, fromSafePromise, Result, ResultAsync } from
     });
   });
 })();
+
+
+(function describe(_ = 'Utility types') {
+  (function describe(_ = 'Transpose') {
+    (function it(_ = 'should transpose an array') {
+      const input: [
+        [ 1, 2 ],
+        [ 3, 4 ],
+        [ 5, 6 ]
+      ] = [
+        [ 1, 2 ],
+        [ 3, 4 ],
+        [ 5, 6 ]
+        ]
+      
+      type Expectation = [
+        [ 1, 3, 5 ],
+        [ 2, 4, 6 ]
+      ]
+
+      const transposed: Expectation = transpose(input)
+    });
+
+    (function it(_ = 'should transpose an empty array') {
+      const input: [] = []
+
+      type Expectation = []
+
+      const transposed: Expectation = transpose(input)
+    });
+
+    (function it(_ = 'should transpose incomplete array') {
+      const input: [
+        [ 1, 3 ],
+        [ 2,   ]
+      ] = [
+        [ 1, 3 ],
+        [ 2,   ]
+      ]
+
+      type Expectation = [[1], [3]]
+
+      const transposed: Expectation = transpose<typeof input>(input)
+    });
+  });
+})();
+
+//#region Utility function declarations for type testing
+
+// Transpose method converts [x, y] pairs into [xs, ys] array.
+declare function transpose<
+  A extends unknown[][]
+>(input: A): Transpose<[ ...A ]>;
+
+//#endregion

--- a/tests/typecheck-tests.ts
+++ b/tests/typecheck-tests.ts
@@ -620,7 +620,7 @@ import { Transpose } from '../src/result'
     });
 
     (function it(_ = 'combines only err results into one') {
-      type Expectation = Result<never, [number, string]>;
+      type Expectation = Result<[ never, never ], [number, string]>;
 
       const result: Expectation = Result.combineWithAllErrors([
         err(1),

--- a/tests/typecheck-tests.ts
+++ b/tests/typecheck-tests.ts
@@ -3,7 +3,7 @@
  *
  * This file is ran during CI to ensure that there aren't breaking changes with types
  */
-import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
+import { err, errAsync, ok, okAsync, Result, ResultAsync } from '../src'
 
 (function describe(_ = 'Result') {
   (function describe(_ = 'andThen') {
@@ -544,14 +544,14 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
 (function describe(_ = 'Combine on Unbounded lists') {
   (function describe(_ = 'combine') {
     (function it(_ = 'combines different results into one') {
-      type Expectation = Result<[ number, string ], Error | string[]>;
+      type Expectation = Result<[ number, string, boolean, boolean ], Error | string | string[]>;
 
       const result: Expectation = Result.combine([
-        ok(1),
-        ok('string'),
-        err([ 'string', 'string2' ]),
-        err(new Error('error content')),
-      ]);
+        ok<number, string>(1),
+        ok<string, string>('string'),
+        err<boolean, string[]>([ 'string', 'string2' ]),
+        err<boolean, Error>(new Error('error content')),
+      ])
     });
 
     (function it(_ = 'combines only ok results into one') {
@@ -564,7 +564,7 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
     });
 
     (function it(_ = 'combines only err results into one') {
-      type Expectation = Result<never, number | string>;
+      type Expectation = Result<[ never, never ], number | string>;
 
       const result: Expectation = Result.combine([
         err(1),
@@ -573,7 +573,7 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
     });
 
     (function it(_ = 'combines empty list results into one') {
-      type Expectation = Result<never, never>;
+      type Expectation = Result<never[], never>;
 
       const result: Expectation = Result.combine([]);
     });
@@ -581,7 +581,7 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
 
   (function describe(_ = 'combineWithAllErrors') {
     (function it(_ = 'combines different results into one') {
-      type Expectation = Result<[ number, string ], (Error | string[])[]>;
+      type Expectation = Result<[ number, string, never, never ], [never, never, string[], Error]>;
 
       const result: Expectation = Result.combineWithAllErrors([
         ok(1),
@@ -601,7 +601,7 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
     });
 
     (function it(_ = 'combines only err results into one') {
-      type Expectation = Result<never, (string | number)[]>;
+      type Expectation = Result<never, [number, string]>;
 
       const result: Expectation = Result.combineWithAllErrors([
         err(1),

--- a/tests/typecheck-tests.ts
+++ b/tests/typecheck-tests.ts
@@ -544,7 +544,7 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
 (function describe(_ = 'Combine on Unbounded lists') {
   (function describe(_ = 'combine') {
     (function it(_ = 'combines different results into one') {
-      type Expectation = Result<number | string, Error | string[]>;
+      type Expectation = Result<[ number, string ], Error | string[]>;
 
       const result: Expectation = Result.combine([
         ok(1),
@@ -555,7 +555,7 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
     });
 
     (function it(_ = 'combines only ok results into one') {
-      type Expectation = Result<number | string, never>;
+      type Expectation = Result<[ number, string ], never>;
 
       const result: Expectation = Result.combine([
         ok(1),
@@ -581,9 +581,9 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
 
   (function describe(_ = 'combineWithAllErrors') {
     (function it(_ = 'combines different results into one') {
-      type Expectation = Result<number | string, (Error | string[])[]>;
+      type Expectation = Result<[ number, string ], (Error | string[])[]>;
 
-      const result = Result.combineWithAllErrors([
+      const result: Expectation = Result.combineWithAllErrors([
         ok(1),
         ok('string'),
         err([ 'string', 'string2' ]),
@@ -592,7 +592,7 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
     });
 
     (function it(_ = 'combines only ok results into one') {
-      type Expectation = Result<number | string, never[]>;
+      type Expectation = Result<[ number, string ], never[]>;
 
       const result: Expectation = Result.combineWithAllErrors([
         ok(1),

--- a/tests/typecheck-tests.ts
+++ b/tests/typecheck-tests.ts
@@ -542,7 +542,72 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
 
 
 (function describe(_ = 'Combine on Unbounded lists') {
-  // TODO:
-  // https://github.com/supermacro/neverthrow/issues/226
+  (function describe(_ = 'combine') {
+    (function it(_ = 'combines different results into one') {
+      type Expectation = Result<number | string, Error | string[]>;
+
+      const result: Expectation = Result.combine([
+        ok(1),
+        ok('string'),
+        err([ 'string', 'string2' ]),
+        err(new Error('error content')),
+      ]);
+    });
+
+    (function it(_ = 'combines only ok results into one') {
+      type Expectation = Result<number | string, never>;
+
+      const result: Expectation = Result.combine([
+        ok(1),
+        ok('string'),
+      ]);
+    });
+
+    (function it(_ = 'combines only err results into one') {
+      type Expectation = Result<never, number | string>;
+
+      const result: Expectation = Result.combine([
+        err(1),
+        err('string'),
+      ]);
+    });
+
+    (function it(_ = 'combines empty list results into one') {
+      type Expectation = Result<never, never>;
+
+      const result: Expectation = Result.combine([]);
+    });
+  });
+
+  (function describe(_ = 'combineWithAllErrors') {
+    (function it(_ = 'combines different results into one') {
+      type Expectation = Result<number | string, (Error | string[])[]>;
+
+      const result = Result.combineWithAllErrors([
+        ok(1),
+        ok('string'),
+        err([ 'string', 'string2' ]),
+        err(new Error('error content')),
+      ]);
+    });
+
+    (function it(_ = 'combines only ok results into one') {
+      type Expectation = Result<number | string, never[]>;
+
+      const result: Expectation = Result.combineWithAllErrors([
+        ok(1),
+        ok('string'),
+      ]);
+    });
+
+    (function it(_ = 'combines only err results into one') {
+      type Expectation = Result<never, (string | number)[]>;
+
+      const result: Expectation = Result.combineWithAllErrors([
+        err(1),
+        err('string'),
+      ]);
+    });
+  });
 })();
 


### PR DESCRIPTION
Hello,

This PR solves the type problem of the `combine` and `combineWithAllErrors` methods as described [here](https://github.com/supermacro/neverthrow/issues/226).
