### PR TITLE
Let fromSafePromise properly infer err type from usage

### DIFF
--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -17,8 +17,8 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
     this._promise = res
   }
 
-  static fromSafePromise<T, E>(promise: PromiseLike<T>): ResultAsync<T, E>
-  static fromSafePromise<T, E>(promise: Promise<T>): ResultAsync<T, E> {
+  static fromSafePromise<T, E = never>(promise: PromiseLike<T>): ResultAsync<T, E>
+  static fromSafePromise<T, E = never>(promise: Promise<T>): ResultAsync<T, E> {
     const newPromise = promise.then((value: T) => new Ok<T, E>(value))
 
     return new ResultAsync(newPromise)

--- a/tests/typecheck-tests.ts
+++ b/tests/typecheck-tests.ts
@@ -3,7 +3,7 @@
  *
  * This file is ran during CI to ensure that there aren't breaking changes with types
  */
-import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
+import { ok, err, okAsync, errAsync, fromSafePromise, Result, ResultAsync } from '../src'
 
 (function describe(_ = 'Result') {
   (function describe(_ = 'andThen') {
@@ -460,6 +460,15 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
           })
       });
     });
+
+    (function describe(_ = 'fromSafePromise') {
+      (function it(_ = 'infers err type from usage') {
+        type Expectation = ResultAsync<number, 'impossible error'>
+
+        const result: Expectation = fromSafePromise(new Promise<number>((resolve) => resolve(123)))
+          .map((val) => val)
+      });
+    });
   });
 
   (function describe(_ = 'orElse') {
@@ -545,4 +554,3 @@ import { ok, err, okAsync, errAsync, Result, ResultAsync } from '../src'
   // TODO:
   // https://github.com/supermacro/neverthrow/issues/226
 })();
-


### PR DESCRIPTION
As suggested by @msheakoski, we simply default to using `never` as the err type of `fromSafePromise` when type inference fails (would be `unknown` otherwise).

Basically, you can choose to see your `never` as any specific type, but it isn't legal to do anything with your `unknown`.

I added @lmcsu and @msheakoski as co-authors.

Resolves #407