### PR TITLE
Improve combine type to create a tuple of the input types

### DIFF
--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -34,7 +34,7 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
   }
 
   static combine<T extends readonly ResultAsync<unknown, unknown>[]>(
-    asyncResultList: T,
+    asyncResultList: [...T],
   ): ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number]> {
     return combineResultAsyncList(asyncResultList) as ResultAsync<
       ExtractOkAsyncTypes<T>,
@@ -43,7 +43,7 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
   }
 
   static combineWithAllErrors<T extends readonly ResultAsync<unknown, unknown>[]>(
-    asyncResultList: T,
+    asyncResultList: [...T],
   ): ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number][]> {
     return combineResultAsyncListWithAllErrors(asyncResultList) as ResultAsync<
       ExtractOkAsyncTypes<T>,

--- a/src/result.ts
+++ b/src/result.ts
@@ -34,13 +34,13 @@ export namespace Result {
   }
 
   export function combine<T extends readonly Result<unknown, unknown>[]>(
-    resultList: T,
+    resultList: [...T],
   ): Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number]> {
     return combineResultList(resultList) as Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number]>
   }
 
   export function combineWithAllErrors<T extends readonly Result<unknown, unknown>[]>(
-    resultList: T,
+    resultList: [...T],
   ): Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number][]> {
     return combineResultListWithAllErrors(resultList) as Result<
       ExtractOkTypes<T>,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -587,7 +587,7 @@ describe('Utils', () => {
       it('Combines `testdouble` proxies from mocks generated via interfaces', async () => {
         const mock = td.object<ITestInterface>()
 
-        const result = await ResultAsync.combine([okAsync(mock)] as const)
+        const result = await ResultAsync.combine([okAsync(mock)])
 
         expect(result).toBeDefined()
         expect(result.isErr()).toBeFalsy()

--- a/tests/typecheck-tests.ts
+++ b/tests/typecheck-tests.ts
@@ -233,6 +233,34 @@ import { ok, err, okAsync, errAsync, fromSafePromise, Result, ResultAsync } from
         .asyncAndThen((val) => errAsync<string, string[]>(['oh nooooo']))
     });
   });
+
+  (function combine(_ = 'combine') {
+    (function it(_ = 'creates a tuple type of input results') {
+      type Expectation = Result<[number, string], unknown>
+
+      const result: Expectation = Result.combine([ok(123), ok('string')])
+    });
+
+    (function it(_ = 'still creates array type when input is array') {
+      type Expectation = Result<number[], unknown>;
+
+      const result: Expectation = Result.combine([].map((_, i) => ok(i)));
+    });
+  });
+
+  (function combine(_ = 'combineWithAllErrors') {
+    (function it(_ = 'creates a tuple type of input results') {
+      type Expectation = Result<[number, string], unknown>
+
+      const result: Expectation = Result.combineWithAllErrors([ok(123), ok('string')]);
+    });
+
+    (function it(_ = 'still creates array type when input is array') {
+      type Expectation = Result<number[], unknown>;
+
+      const result: Expectation = Result.combine([].map((_, i) => ok(i)));
+    });
+  });
 });
 
 
@@ -545,6 +573,34 @@ import { ok, err, okAsync, errAsync, fromSafePromise, Result, ResultAsync } from
               return errAsync('1')
           }
         })
+    });
+  });
+
+  (function combine(_ = 'combine') {
+    (function it(_ = 'creates a tuple type of input results') {
+      type Expectation = ResultAsync<[number, string], unknown>
+
+      const result: Expectation = ResultAsync.combine([okAsync(123), okAsync('string')])
+    });
+
+    (function it(_ = 'still creates array type when input is array') {
+      type Expectation = ResultAsync<number[], unknown>;
+
+      const result: Expectation = ResultAsync.combine([].map((_, i) => okAsync(i)));
+    });
+  });
+
+  (function combine(_ = 'combineWithAllErrors') {
+    (function it(_ = 'creates a tuple type of input results') {
+      type Expectation = ResultAsync<[number, string], unknown>
+
+      const result: Expectation = ResultAsync.combineWithAllErrors([okAsync(123), okAsync('string')]);
+    });
+
+    (function it(_ = 'still creates array type when input is array') {
+      type Expectation = ResultAsync<number[], unknown>;
+
+      const result: Expectation = ResultAsync.combine([].map((_, i) => okAsync(i)));
     });
   });
 });


### PR DESCRIPTION
G'day, this PR improves the type of the `.combine()` functions to create a tuple of the input types.

In the following situation:
```ts
const result = Result.combine([ok(1234), ok("string")]);
```
This would previously result in this type:
`Result<(number | string)[], unknown>`

This change will improve this type to be more specific when a tuple of results is passed in:
`Result<[number, string], unknown>`

This change remains compatible if you pass an array of types in.
Ie, `Result.combine(arrayOfNumbers.map(x => ok(x))` would still create the type: `Result<number[], unknown>`.

I have added type tests for these situations.

_Side note: it seems prettier hasn't been run in the tests folder for some time, I have avoiding running it in this PR to prevent clutter._