### PR TITLE
Fix types for Result.combine and ResultAsync.combine for arrays witho…

### DIFF
--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -11,6 +11,8 @@ import { Err, Ok, Result } from './'
 import {
   combineResultAsyncList,
   combineResultAsyncListWithAllErrors,
+  ExtractErrAsyncTypes,
+  ExtractOkAsyncTypes,
   InferAsyncErrTypes,
   InferAsyncOkTypes,
   InferErrTypes,
@@ -154,10 +156,18 @@ export const fromPromise = ResultAsync.fromPromise
 export const fromSafePromise = ResultAsync.fromSafePromise
 
 // Combines the array of async results into one result.
-export type CombineResultAsyncs<T> = TraverseAsync<UnwrapAsync<T>>
+export type CombineResultAsyncs<
+  T extends readonly ResultAsync<unknown, unknown>[]
+> = IsLiteralArray<T> extends 1
+  ? TraverseAsync<UnwrapAsync<T>>
+  : ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number]>
 
 // Combines the array of async results into one result with all errors.
-export type CombineResultsWithAllErrorsArrayAsync<T> = TraverseWithAllErrorsAsync<UnwrapAsync<T>>
+export type CombineResultsWithAllErrorsArrayAsync<
+  T extends readonly ResultAsync<unknown, unknown>[]
+> = IsLiteralArray<T> extends 1
+  ? TraverseWithAllErrorsAsync<UnwrapAsync<T>>
+  : ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number][]>
 
 // Unwraps the inner `Result` from a `ResultAsync` for all elements.
 type UnwrapAsync<T> = IsLiteralArray<T> extends 1

--- a/tests/typecheck-tests.ts
+++ b/tests/typecheck-tests.ts
@@ -243,6 +243,116 @@ import { Transpose } from '../src/result'
         .asyncAndThen((val) => errAsync<string, string[]>(['oh nooooo']))
     });
   });
+
+  (function describe(_ = 'combine') {
+    (function it(_ = 'combines different results into one') {
+      type Expectation = Result<[ number, string, boolean, boolean ], Error | string | string[]>;
+
+      const result = Result.combine([
+        ok<number, string>(1),
+        ok<string, string>('string'),
+        err<boolean, string[]>([ 'string', 'string2' ]),
+        err<boolean, Error>(new Error('error content')),
+      ])
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+
+    (function it(_ = 'combines only ok results into one') {
+      type Expectation = Result<[ number, string ], never>;
+
+      const result = Result.combine([
+        ok(1),
+        ok('string'),
+      ]);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+
+    (function it(_ = 'combines only err results into one') {
+      type Expectation = Result<[ never, never ], number | string>;
+
+      const result = Result.combine([
+        err(1),
+        err('string'),
+      ]);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+
+    (function it(_ = 'combines empty list results into one') {
+      type Expectation = Result<never, never>;
+      const results: [] = [];
+
+      const result = Result.combine(results);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+
+    (function it(_ = 'combines arrays of results to a result of an array') {
+      type Expectation = Result<string[], string>;
+      const results: Result<string, string>[] = [];
+
+      const result = Result.combine(results);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+  });
+
+  (function describe(_ = 'combineWithAllErrors') {
+    (function it(_ = 'combines different results into one') {
+      type Expectation = Result<[ number, string, never, never ], [never, never, string[], Error]>;
+
+      const result = Result.combineWithAllErrors([
+        ok(1),
+        ok('string'),
+        err([ 'string', 'string2' ]),
+        err(new Error('error content')),
+      ]);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+
+    (function it(_ = 'combines only ok results into one') {
+      type Expectation = Result<[ number, string ], [never, never]>;
+
+      const result = Result.combineWithAllErrors([
+        ok(1),
+        ok('string'),
+      ]);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+
+    (function it(_ = 'combines only err results into one') {
+      type Expectation = Result<[ never, never ], [number, string]>;
+
+      const result = Result.combineWithAllErrors([
+        err(1),
+        err('string'),
+      ]);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+
+    (function it(_ = 'combines arrays of results to a result of an array') {
+      type Expectation = Result<string[], (number | string)[]>;
+      const results: Result<string, number | string>[] = [];
+
+      const result = Result.combineWithAllErrors(results);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+  });
 });
 
 
@@ -557,79 +667,117 @@ import { Transpose } from '../src/result'
         })
     });
   });
-});
 
-
-(function describe(_ = 'Combine on Unbounded lists') {
   (function describe(_ = 'combine') {
-    (function it(_ = 'combines different results into one') {
-      type Expectation = Result<[ number, string, boolean, boolean ], Error | string | string[]>;
+    (function it(_ = 'combines different result asyncs into one') {
+      type Expectation = ResultAsync<[ number, string, boolean, boolean ], Error | string | string[]>;
 
-      const result: Expectation = Result.combine([
-        ok<number, string>(1),
-        ok<string, string>('string'),
-        err<boolean, string[]>([ 'string', 'string2' ]),
-        err<boolean, Error>(new Error('error content')),
+      const result = ResultAsync.combine([
+        okAsync<number, string>(1),
+        okAsync<string, string>('string'),
+        errAsync<boolean, string[]>([ 'string', 'string2' ]),
+        errAsync<boolean, Error>(new Error('error content')),
       ])
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
     });
 
-    (function it(_ = 'combines only ok results into one') {
-      type Expectation = Result<[ number, string ], never>;
+    (function it(_ = 'combines only ok result asyncs into one') {
+      type Expectation = ResultAsync<[ number, string ], never>;
 
-      const result: Expectation = Result.combine([
-        ok(1),
-        ok('string'),
+      const result = ResultAsync.combine([
+        okAsync(1),
+        okAsync('string'),
       ]);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
     });
 
     (function it(_ = 'combines only err results into one') {
-      type Expectation = Result<[ never, never ], number | string>;
+      type Expectation = ResultAsync<[ never, never ], number | string>;
 
-      const result: Expectation = Result.combine([
-        err(1),
-        err('string'),
+      const result = ResultAsync.combine([
+        errAsync(1),
+        errAsync('string'),
       ]);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
     });
 
-    (function it(_ = 'combines empty list results into one') {
-      type Expectation = Result<never[], never>;
+    (function it(_ = 'combines empty list result asyncs into one') {
+      type Expectation = ResultAsync<never, never>;
+      const results: [] = [];
 
-      const result: Expectation = Result.combine([]);
+      const result = ResultAsync.combine(results);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+
+    (function it(_ = 'combines arrays of result asyncs to a result async of an array') {
+      type Expectation = ResultAsync<string[], string>;
+      const results: ResultAsync<string, string>[] = [];
+
+      const result = ResultAsync.combine(results);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
     });
   });
 
   (function describe(_ = 'combineWithAllErrors') {
-    (function it(_ = 'combines different results into one') {
-      type Expectation = Result<[ number, string, never, never ], [never, never, string[], Error]>;
+    (function it(_ = 'combines different result asyncs into one') {
+      type Expectation = ResultAsync<[ number, string, never, never ], [never, never, string[], Error]>;
 
-      const result: Expectation = Result.combineWithAllErrors([
-        ok(1),
-        ok('string'),
-        err([ 'string', 'string2' ]),
-        err(new Error('error content')),
+      const result = ResultAsync.combineWithAllErrors([
+        okAsync(1),
+        okAsync('string'),
+        errAsync([ 'string', 'string2' ]),
+        errAsync(new Error('error content')),
       ]);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
     });
 
-    (function it(_ = 'combines only ok results into one') {
-      type Expectation = Result<[ number, string ], never[]>;
+    (function it(_ = 'combines only ok result asyncs into one') {
+      type Expectation = ResultAsync<[ number, string ], [never, never]>;
 
-      const result: Expectation = Result.combineWithAllErrors([
-        ok(1),
-        ok('string'),
+      const result = ResultAsync.combineWithAllErrors([
+        okAsync(1),
+        okAsync('string'),
       ]);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
     });
 
-    (function it(_ = 'combines only err results into one') {
-      type Expectation = Result<[ never, never ], [number, string]>;
+    (function it(_ = 'combines only err result asyncs into one') {
+      type Expectation = ResultAsync<[ never, never ], [number, string]>;
 
-      const result: Expectation = Result.combineWithAllErrors([
-        err(1),
-        err('string'),
+      const result = ResultAsync.combineWithAllErrors([
+        errAsync(1),
+        errAsync('string'),
       ]);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
+    });
+
+    (function it(_ = 'combines arrays of result asyncs to a result of an array') {
+      type Expectation = ResultAsync<string[], (number | string)[]>;
+      const results: ResultAsync<string, number | string>[] = [];
+
+      const result = ResultAsync.combineWithAllErrors(results);
+
+      const assignableToCheck: Expectation = result;
+      const assignablefromCheck: typeof result = assignableToCheck;
     });
   });
-})();
-
+});
 
 (function describe(_ = 'Utility types') {
   (function describe(_ = 'Transpose') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "noUnusedLocals": true,
       "noUnusedParameters": true,
       "strictNullChecks": true,
+      "strictFunctionTypes": true,
       "declaration": true,
       "moduleResolution": "Node",
       "baseUrl": "./src",


### PR DESCRIPTION
…ut statically know length

The fix works be using the old implementation for the return types of `combine` and `combineWithAllErrors` in the case that the given array of `Result`s/`ResultAsync`s is not a tuple type.

While implementing this, I actually stumbled across another issue: The types for `combineWithAllErrors` are incorrect in the tuple case. At the moment, it is typed so that the error case also is a tuple of all the error types. But this is not what happens in reality, because not all of the results necessarily are errors. Here is an example:
```ts
const result1: Result<string, string> = ok('foo');
const result2: Result<number, number> = err(42);
const results = Result.combine([result1, result2]); // inferred as Result<[string, number], [string, number]>, but it should be Result<[string, number], (string | number)[]>, because we don't statically know how many of the results are errors.
expect(results).toEqual(err([42]));
```
There was actually a single test case that should have covered this, but it didn't catch it, because so far, we were only testing assignability of the result to the expectation, but not the other way round (and there are other test cases that expect the incorrect types...). I added checks for the other direction, too, so now we actually check for type equality.

The problem itself is however _not_ addressed by this PR and should be addressed separately. I just wanted to write it down so I don't forget. I’ll create an issue for it, when I find the time.

Fixes #434