### PR TITLE
Fix a test to be in an intended way

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -142,7 +142,7 @@ describe('Result.Ok', () => {
       // network calls
       // disk io
       // etc ...
-      return Promise.resolve(ok('Very Nice!'))
+      return Promise.resolve('Very Nice!')
     })
 
     const okVal = ok(12)
@@ -155,6 +155,7 @@ describe('Result.Ok', () => {
 
     expect(newResult.isOk()).toBe(true)
     expect(asyncMapper).toHaveBeenCalledTimes(1)
+    expect(newResult._unsafeUnwrap()).toStrictEqual('Very Nice!')
   })
 
   it('Matches on an Ok', () => {
@@ -265,7 +266,7 @@ describe('Result.Err', () => {
       // network calls
       // disk io
       // etc ...
-      return Promise.resolve(ok('Very Nice!'))
+      return Promise.resolve('Very Nice!')
     })
 
     const errVal = err('nooooooo')


### PR DESCRIPTION
Hi 👋 Not a big deal, but I think the tests were intended like the changes here, altho the original test was not necessarily incorrect. 
As a positive result, `expect(newResult._unsafeUnwrap()).toStrictEqual('Very Nice!')` was able to be added. (For the original setup, the equivalent would have been `expect(newResult._unsafeUnwrap()).toStrictEqual(ok('Very Nice!'))` which would look weird.)