### PR TITLE
feat: add partition static function

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ For asynchronous tasks, `neverthrow` offers a `ResultAsync` class which wraps a 
     - [`Result.combine` (static class method)](#resultcombine-static-class-method)
     - [`Result.combineWithAllErrors` (static class method)](#resultcombinewithallerrors-static-class-method)
     - [`Result.safeUnwrap()`](#resultsafeunwrap)
+    - [`Result.partition (static class method)`](#resultpartition-static-class-method)
   + [Asynchronous API (`ResultAsync`)](#asynchronous-api-resultasync)
     - [`okAsync`](#okasync)
     - [`errAsync`](#errasync)
@@ -53,6 +54,7 @@ For asynchronous tasks, `neverthrow` offers a `ResultAsync` class which wraps a 
     - [`ResultAsync.combine` (static class method)](#resultasynccombine-static-class-method)
     - [`ResultAsync.combineWithAllErrors` (static class method)](#resultasynccombinewithallerrors-static-class-method)
     - [`ResultAsync.safeUnwrap()`](#resultasyncsafeunwrap)
+    - [`ResultAsync.partition (static class method)`](#resultasyncpartition-static-class-method)
   + [Utilities](#utilities)
     - [`fromThrowable`](#fromthrowable)
     - [`fromPromise`](#frompromise)
@@ -673,6 +675,49 @@ Allows for unwrapping a `Result` or returning an `Err` implicitly, thereby reduc
 
 ---
 
+#### `Result.partition` (static class method)
+
+> Although Result is not an actual JS class, the way that `partition` has been implemented requires that you call `partition` as though it were a static method on `Result`. See examples below.
+
+Partition lists of `Result`s.
+
+**`partition` works on both heterogeneous and homogeneous lists**. This means that you can have lists that contain different kinds of `Result`s and still be able to partition them. Note that you cannot partition lists that contain both `Result`s **and** `ResultAsync`s.
+
+The `partition` function takes a list of results and returns a tuple of all `Ok` results and `Err` errors.
+
+Function signature:
+
+```typescript
+// homogeneous lists
+function partition<T, E>(resultList: Result<T, E>[]): [T[], E[]]
+
+// heterogeneous lists
+function partition<T1, T2, E1, E2>(resultList: [ Result<T1, E1>, Result<T2, E2> ]): [(T1 | T2)[], (E1 | E2)[]]
+function partition<T1, T2, T3, E1, E2, E3> => [(T1 | T2 | T3) [], (E1 | E2 | E3)[]]
+function partition<T1, T2, T3, T4, E1, E2, E3, E4> => [(T1 | T2 | T3 | T4)[], (E1 | E2 | E3 | E4)[]]
+// ... etc etc ad infinitum
+```
+
+Example usage:
+
+```typescript
+const resultList: Result<number, string>[] = [
+  ok(123),
+  err('boooom!'),
+  ok(456),
+  err('ahhhhh!'),
+]
+
+const [results, errors] = Result.partition(resultList)
+
+// results is [123, 456]
+// errors is ['boooom!', 'ahhhhh!']
+```
+
+[⬆️  Back to top](#toc)
+
+---
+
 ### Asynchronous API (`ResultAsync`)
 
 #### `okAsync`
@@ -1143,6 +1188,47 @@ const result = ResultAsync.combineWithAllErrors(resultList)
 **⚠️ You must use `.safeUnwrap` in a generator context with `safeTry`**. Please see [safeTry](#safeTry).
 
 Allows for unwrapping a `Result` or returning an `Err` implicitly, thereby reducing boilerplate.
+
+[⬆️  Back to top](#toc)
+
+---
+
+#### `ResultAsync.partition` (static class method)
+
+Partition lists of `ResultAsync`s.
+
+**`partition` works on both heterogeneous and homogeneous lists**. This means that you can have lists that contain different kinds of `ResultAsync`s and still be able to partition them. Note that you cannot partition lists that contain both `Result`s **and** `ResultAsync`s.
+
+The `partition` function takes a list of async results and returns a `Promise` of a tuple of all Ok results and Err errors.
+
+Function signature:
+
+```typescript
+// homogeneous lists
+function partition<T, E>(resultList: ResultAsync<T, E>[]): Promise<[T[], E[]]>
+
+// heterogeneous lists
+function partition<T1, T2, E1, E2>(resultList: [ ResultAsync<T1, E1>, ResultAsync<T2, E2> ]): Promise<[(T1 | T2)[], (E1 | E2)[]]>
+function partition<T1, T2, T3, E1, E2, E3> => Promise<[(T1 | T2 | T3)[], (E1 | E2 | E3)[]]>
+function partition<T1, T2, T3, T4, E1, E2, E3, E4> => Promise<[(T1 | T2 | T3 | T4)[], (E1 | E2 | E3 | E4)[]]>
+// ... etc etc ad infinitum
+```
+
+Example usage:
+
+```typescript
+const resultList: ResultAsync<number, string>[] = [
+  okAsync(123),
+  errAsync('boooom!'),
+  okAsync(456),
+  errAsync('ahhhhh!'),
+]
+
+const [results, errors] = ResultAsync.partition(resultList)
+
+// results is [123, 456]
+// errors is ['boooom!', 'ahhhhh!']
+```
 
 [⬆️  Back to top](#toc)
 

--- a/src/_internals/utils.ts
+++ b/src/_internals/utils.ts
@@ -81,3 +81,14 @@ export const combineResultAsyncListWithAllErrors = <T, E>(
   ResultAsync.fromSafePromise(Promise.all(asyncResultList)).andThen(
     combineResultListWithAllErrors,
   ) as ResultAsync<T[], E[]>
+
+export const partitionResultList = <T, E>(resultList: readonly Result<T, E>[]): [T[], E[]] =>
+  resultList.reduce(
+    ([oks, errors], result) =>
+      result.isErr() ? [oks, [...errors, result.error]] : [[...oks, result.value], errors],
+    [[], []] as [T[], E[]],
+  )
+
+export const partitionResultAsyncList = <T, E>(
+  asyncResultList: readonly ResultAsync<T, E>[],
+): Promise<[T[], E[]]> => Promise.all(asyncResultList).then(partitionResultList)

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -17,6 +17,7 @@ import {
   InferAsyncOkTypes,
   InferErrTypes,
   InferOkTypes,
+  partitionResultAsyncList,
 } from './_internals/utils'
 
 export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
@@ -66,6 +67,18 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
     return combineResultAsyncListWithAllErrors(
       asyncResultList,
     ) as CombineResultsWithAllErrorsArrayAsync<T>
+  }
+
+  static partition<
+    T extends readonly [ResultAsync<unknown, unknown>, ...ResultAsync<unknown, unknown>[]]
+  >(asyncResultList: T): PartitionResultAsync<T>
+  static partition<T extends readonly ResultAsync<unknown, unknown>[]>(
+    asyncResultList: T,
+  ): PartitionResultAsync<T>
+  static partition<T extends readonly ResultAsync<unknown, unknown>[]>(
+    asyncResultList: T,
+  ): PartitionResultAsync<T> {
+    return partitionResultAsyncList(asyncResultList) as PartitionResultAsync<T>
   }
 
   map<A>(f: (t: T) => A | Promise<A>): ResultAsync<A, E> {
@@ -175,6 +188,10 @@ export type CombineResultsWithAllErrorsArrayAsync<
 > = IsLiteralArray<T> extends 1
   ? TraverseWithAllErrorsAsync<UnwrapAsync<T>>
   : ResultAsync<ExtractOkAsyncTypes<T>, ExtractErrAsyncTypes<T>[number][]>
+
+export type PartitionResultAsync<T extends readonly ResultAsync<unknown, unknown>[]> = Promise<
+  [ExtractOkAsyncTypes<T>[number][], ExtractErrAsyncTypes<T>[number][]]
+>
 
 // Unwraps the inner `Result` from a `ResultAsync` for all elements.
 type UnwrapAsync<T> = IsLiteralArray<T> extends 1

--- a/src/result.ts
+++ b/src/result.ts
@@ -7,6 +7,7 @@ import {
   ExtractOkTypes,
   InferErrTypes,
   InferOkTypes,
+  partitionResultList,
 } from './_internals/utils'
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -55,6 +56,18 @@ export namespace Result {
     resultList: T,
   ): CombineResultsWithAllErrorsArray<T> {
     return combineResultListWithAllErrors(resultList) as CombineResultsWithAllErrorsArray<T>
+  }
+
+  export function partition<
+    T extends readonly [Result<unknown, unknown>, ...Result<unknown, unknown>[]]
+  >(resultList: T): PartitionResult<T>
+  export function partition<T extends readonly Result<unknown, unknown>[]>(
+    resultList: T,
+  ): PartitionResult<T>
+  export function partition<T extends readonly Result<unknown, unknown>[]>(
+    resultList: T,
+  ): PartitionResult<T> {
+    return partitionResultList(resultList) as PartitionResult<T>
   }
 }
 
@@ -582,5 +595,10 @@ export type CombineResultsWithAllErrorsArray<
 > = IsLiteralArray<T> extends 1
   ? TraverseWithAllErrors<T>
   : Result<ExtractOkTypes<T>, ExtractErrTypes<T>[number][]>
+
+export type PartitionResult<T extends readonly Result<unknown, unknown>[]> = [
+  ExtractOkTypes<T>[number][],
+  ExtractErrTypes<T>[number][],
+]
 
 //#endregion

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -332,15 +332,15 @@ describe('Result.fromThrowable', () => {
 
   // Added for issue #300 -- the test here is not so much that expectations are met as that the test compiles.
   it('Accepts an inner function which takes arguments', () => {
-    const hello = (fname: string): string => `hello, ${fname}`;
-    const safeHello = Result.fromThrowable(hello);
+    const hello = (fname: string): string => `hello, ${fname}`
+    const safeHello = Result.fromThrowable(hello)
 
-    const result = hello('Dikembe');
-    const safeResult = safeHello('Dikembe');
+    const result = hello('Dikembe')
+    const safeResult = safeHello('Dikembe')
 
-    expect(safeResult).toBeInstanceOf(Ok);
-    expect(result).toEqual(safeResult._unsafeUnwrap());
-  });
+    expect(safeResult).toBeInstanceOf(Ok)
+    expect(result).toEqual(safeResult._unsafeUnwrap())
+  })
 
   it('Creates a function that returns an err when the inner function throws', () => {
     const thrower = (): string => {
@@ -375,7 +375,7 @@ describe('Result.fromThrowable', () => {
   })
 
   it('has a top level export', () => {
-      expect(fromThrowable).toBe(Result.fromThrowable)
+    expect(fromThrowable).toBe(Result.fromThrowable)
   })
 })
 
@@ -406,15 +406,15 @@ describe('Utils', () => {
       })
 
       it('Combines heterogeneous lists', () => {
-        type HeterogenousList = [ Result<string, string>, Result<number, number>, Result<boolean, boolean> ]
-
-        const heterogenousList: HeterogenousList = [
-          ok('Yooooo'),
-          ok(123),
-          ok(true),
+        type HeterogenousList = [
+          Result<string, string>,
+          Result<number, number>,
+          Result<boolean, boolean>,
         ]
 
-        type ExpecteResult = Result<[ string, number, boolean ], string | number | boolean>
+        const heterogenousList: HeterogenousList = [ok('Yooooo'), ok(123), ok(true)]
+
+        type ExpecteResult = Result<[string, number, boolean], string | number | boolean>
 
         const result: ExpecteResult = Result.combine(heterogenousList)
 
@@ -422,21 +422,18 @@ describe('Utils', () => {
       })
 
       it('Does not destructure / concatenate arrays', () => {
-        type HomogenousList = [
-          Result<string[], boolean>,
-          Result<number[], string>,
-        ]
+        type HomogenousList = [Result<string[], boolean>, Result<number[], string>]
 
-        const homogenousList: HomogenousList = [
-          ok(['hello', 'world']),
-          ok([1, 2, 3])
-        ]
+        const homogenousList: HomogenousList = [ok(['hello', 'world']), ok([1, 2, 3])]
 
-        type ExpectedResult = Result<[ string[], number[] ], boolean | string>
+        type ExpectedResult = Result<[string[], number[]], boolean | string>
 
         const result: ExpectedResult = Result.combine(homogenousList)
 
-        expect(result._unsafeUnwrap()).toEqual([ [ 'hello', 'world' ], [ 1, 2, 3 ]])
+        expect(result._unsafeUnwrap()).toEqual([
+          ['hello', 'world'],
+          [1, 2, 3],
+        ])
       })
     })
 
@@ -445,7 +442,7 @@ describe('Utils', () => {
         const asyncResultList = [okAsync(123), okAsync(456), okAsync(789)]
 
         const resultAsync: ResultAsync<number[], never[]> = ResultAsync.combine(asyncResultList)
-        
+
         expect(resultAsync).toBeInstanceOf(ResultAsync)
 
         const result = await ResultAsync.combine(asyncResultList)
@@ -480,14 +477,14 @@ describe('Utils', () => {
           okAsync('Yooooo'),
           okAsync(123),
           okAsync(true),
-          okAsync([ 1, 2, 3]),
+          okAsync([1, 2, 3]),
         ]
 
-        type ExpecteResult = Result<[ string, number, boolean, number[] ], string | number | boolean>
+        type ExpecteResult = Result<[string, number, boolean, number[]], string | number | boolean>
 
         const result: ExpecteResult = await ResultAsync.combine(heterogenousList)
 
-        expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true, [ 1, 2, 3 ]])
+        expect(result._unsafeUnwrap()).toEqual(['Yooooo', 123, true, [1, 2, 3]])
       })
     })
   })
@@ -517,15 +514,15 @@ describe('Utils', () => {
       })
 
       it('Combines heterogeneous lists', () => {
-        type HeterogenousList = [ Result<string, string>, Result<number, number>, Result<boolean, boolean> ]
-
-        const heterogenousList: HeterogenousList = [
-          ok('Yooooo'),
-          ok(123),
-          ok(true),
+        type HeterogenousList = [
+          Result<string, string>,
+          Result<number, number>,
+          Result<boolean, boolean>,
         ]
 
-        type ExpecteResult = Result<[ string, number, boolean ], (string | number | boolean)[]>
+        const heterogenousList: HeterogenousList = [ok('Yooooo'), ok(123), ok(true)]
+
+        type ExpecteResult = Result<[string, number, boolean], (string | number | boolean)[]>
 
         const result: ExpecteResult = Result.combineWithAllErrors(heterogenousList)
 
@@ -533,21 +530,18 @@ describe('Utils', () => {
       })
 
       it('Does not destructure / concatenate arrays', () => {
-        type HomogenousList = [
-          Result<string[], boolean>,
-          Result<number[], string>,
-        ]
+        type HomogenousList = [Result<string[], boolean>, Result<number[], string>]
 
-        const homogenousList: HomogenousList = [
-          ok(['hello', 'world']),
-          ok([1, 2, 3])
-        ]
+        const homogenousList: HomogenousList = [ok(['hello', 'world']), ok([1, 2, 3])]
 
-        type ExpectedResult = Result<[ string[], number[] ], (boolean | string)[]>
+        type ExpectedResult = Result<[string[], number[]], (boolean | string)[]>
 
         const result: ExpectedResult = Result.combineWithAllErrors(homogenousList)
 
-        expect(result._unsafeUnwrap()).toEqual([ [ 'hello', 'world' ], [ 1, 2, 3 ]])
+        expect(result._unsafeUnwrap()).toEqual([
+          ['hello', 'world'],
+          [1, 2, 3],
+        ])
       })
     })
     describe('`ResultAsync.combineWithAllErrors`', () => {
@@ -575,15 +569,15 @@ describe('Utils', () => {
       })
 
       it('Combines heterogeneous lists', async () => {
-        type HeterogenousList = [ ResultAsync<string, string>, ResultAsync<number, number>, ResultAsync<boolean, boolean> ]
-
-        const heterogenousList: HeterogenousList = [
-          okAsync('Yooooo'),
-          okAsync(123),
-          okAsync(true),
+        type HeterogenousList = [
+          ResultAsync<string, string>,
+          ResultAsync<number, number>,
+          ResultAsync<boolean, boolean>,
         ]
 
-        type ExpecteResult = Result<[ string, number, boolean ], [string, number, boolean]>
+        const heterogenousList: HeterogenousList = [okAsync('Yooooo'), okAsync(123), okAsync(true)]
+
+        type ExpecteResult = Result<[string, number, boolean], [string, number, boolean]>
 
         const result: ExpecteResult = await ResultAsync.combineWithAllErrors(heterogenousList)
 
@@ -609,6 +603,123 @@ describe('Utils', () => {
 
         expect(unwrappedResult.length).toBe(1)
         expect(unwrappedResult[0]).toBe(mock)
+      })
+    })
+  })
+  describe('`Result.partition`', () => {
+    describe('Synchronous `partition`', () => {
+      it('Partitions a list of results into an Ok value', () => {
+        const resultList = [ok(123), ok(456), ok(789)]
+
+        const [results, errors] = Result.partition(resultList)
+
+        expect(results).toEqual([123, 456, 789])
+        expect(errors).toEqual([])
+      })
+
+      it('Partitions a list of results into an Err value', () => {
+        const resultList: Result<number, string>[] = [
+          ok(123),
+          err('boooom!'),
+          ok(456),
+          err('ahhhhh!'),
+        ]
+
+        const [results, errors] = Result.partition(resultList)
+
+        expect(results).toEqual([123, 456])
+        expect(errors).toEqual(['boooom!', 'ahhhhh!'])
+      })
+
+      it('Partitions heterogeneous lists', () => {
+        type HeterogenousList = [
+          Result<string, string>,
+          Result<number, number>,
+          Result<boolean, boolean>,
+        ]
+
+        const heterogenousList: HeterogenousList = [ok('Yooooo'), ok(123), ok(true)]
+
+        type ExpecteResult = [(string | number | boolean)[], (string | number | boolean)[]]
+
+        const [results, errors]: ExpecteResult = Result.partition(heterogenousList)
+
+        expect(results).toEqual(['Yooooo', 123, true])
+        expect(errors).toEqual([])
+      })
+
+      it('Does not destructure / concatenate arrays', () => {
+        type HomogenousList = [Result<string[], boolean>, Result<number[], string>]
+
+        const homogenousList: HomogenousList = [ok(['hello', 'world']), ok([1, 2, 3])]
+
+        type ExpectedResult = [(string[] | number[])[], (boolean | string)[]]
+
+        const [results, errors]: ExpectedResult = Result.partition(homogenousList)
+
+        expect(results).toEqual([
+          ['hello', 'world'],
+          [1, 2, 3],
+        ])
+        expect(errors).toEqual([])
+      })
+    })
+    describe('`ResultAsync.partition`', () => {
+      it('Partitions a list of async results into an Ok value', async () => {
+        const asyncResultList = [okAsync(123), okAsync(456), okAsync(789)]
+
+        const [results, errors] = await ResultAsync.partition(asyncResultList)
+
+        expect(results).toEqual([123, 456, 789])
+        expect(errors).toEqual([])
+      })
+
+      it('Partitions a list of results into an Err value', async () => {
+        const asyncResultList: ResultAsync<number, string>[] = [
+          okAsync(123),
+          errAsync('boooom!'),
+          okAsync(456),
+          errAsync('ahhhhh!'),
+        ]
+
+        const [results, errors] = await ResultAsync.partition(asyncResultList)
+
+        expect(results).toEqual([123, 456])
+        expect(errors).toEqual(['boooom!', 'ahhhhh!'])
+      })
+
+      it('Partitions heterogeneous lists', async () => {
+        type HeterogenousList = [
+          ResultAsync<string, string>,
+          ResultAsync<number, number>,
+          ResultAsync<boolean, boolean>,
+        ]
+
+        const heterogenousList: HeterogenousList = [okAsync('Yooooo'), okAsync(123), okAsync(true)]
+
+        type ExpecteResult = [(string | number | boolean)[], (string | number | boolean)[]]
+
+        const [results, errors]: ExpecteResult = await ResultAsync.partition(heterogenousList)
+
+        expect(results).toEqual(['Yooooo', 123, true])
+        expect(errors).toEqual([])
+      })
+    })
+
+    describe('testdouble `ResultAsync.partition`', () => {
+      interface ITestInterface {
+        getName(): string
+        setName(name: string): void
+        getAsyncResult(): ResultAsync<ITestInterface, Error>
+      }
+
+      it('Partitions `testdouble` proxies from mocks generated via interfaces', async () => {
+        const mock = td.object<ITestInterface>()
+
+        const [results] = await ResultAsync.partition([okAsync(mock)] as const)
+
+        expect(results.length).toBe(1)
+        expect(results[0]).toBe(mock)
       })
     })
   })
@@ -830,7 +941,6 @@ describe('ResultAsync', () => {
     it('Skips orElse on an Ok value', async () => {
       const okVal = okAsync(12)
       const errorCallback = jest.fn((_errVal) => errAsync<number, string>('It is now a string'))
-
 
       const result = await okVal.orElse(errorCallback)
 


### PR DESCRIPTION
Hi,

added `partition` function to handle scenarios when you need to get a tuple of all results and errors. Inspired by [lodash partition](https://lodash.com/docs/4.17.15#partition)