### PR TITLE
fix: set prepack to ensure the build before pack/publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write 'src/**/*.ts?(x)' && npm run lint -- --fix",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf ./dist ./tmp",
-    "build": "npm run clean && rollup --config && mv tmp/*.js dist"
+    "build": "npm run clean && rollup --config && mv tmp/*.js dist",
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Set `prepack` (see https://docs.npmjs.com/cli/v10/using-npm/scripts for details) to ensure the build before `pack`/`publish` to prevent an issue like #532. 