### PR TITLE
fix: use node:14.18.3 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   install_deps:
     docker:
-      - image: cimg/node:14.17.1 
+      - image: cimg/node:14.18.3
     steps:
       - checkout
       - run:


### PR DESCRIPTION
I think this PR will fix the error #517 made

Node.js@14.17.1 doesn't support import from 'node:worker_threads'
https://app.circleci.com/pipelines/github/supermacro/neverthrow/1188/workflows/66b06c8d-9834-4e22-b0b0-b264941e3944/jobs/4644?invite=true#step-103-157_44

Reproduction
- fetch #517 and run the tests with Node.js@14.17.1
- switch to 14.18.3 then you pass the tests