### PR TITLE
chore: replace CircleCI status with GHA action status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: CI
 on:
   pull_request:
+  push:
+    branches:
+      - master
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # NeverThrow 🙅
 
-[![supermacro](https://circleci.com/gh/supermacro/neverthrow.svg?style=svg)](https://app.circleci.com/pipelines/github/supermacro/neverthrow)
+[![GitHub Workflow Status](https://github.com/supermacro/neverthrow/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/supermacro/neverthrow/actions)
 
 ## Description
 


### PR DESCRIPTION
Run `ci.yml` on master push and replace CircleCI status with GHA action status.

<img width="366" alt="image" src="https://github.com/supermacro/neverthrow/assets/12842076/8f4b6f19-ef5f-4a83-8ea5-f317ed76e78a">
