### PR TITLE
add test_result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,10 @@ jobs:
           key: depends-node${{ env.RUNNER_NODE_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: test
         run: npm run test
+  test_result:
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ always() }}
+    steps:
+      - run: exit 1
+        if: ${{ needs.test.result != 'success' }}


### PR DESCRIPTION
`test_result` succeeds if all tests are passed, so now you don't need to set each test job as the required status.

See https://github.com/orgs/community/discussions/26822#discussioncomment-3253537