### PR TITLE
Made err() infer strings narrowly for easier error tagging

### DIFF
--- a/.changeset/three-mice-act.md
+++ b/.changeset/three-mice-act.md
@@ -1,0 +1,5 @@
+---
+"neverthrow": patch
+---
+
+Made err() infer strings narrowly for easier error tagging.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neverthrow",
-  "version": "7.0.1",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neverthrow",
-      "version": "7.0.1",
+      "version": "7.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -8500,7 +8500,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neverthrow",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neverthrow",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -8500,6 +8500,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },

--- a/src/result.ts
+++ b/src/result.ts
@@ -62,7 +62,11 @@ export type Result<T, E> = Ok<T, E> | Err<T, E>
 
 export const ok = <T, E = never>(value: T): Ok<T, E> => new Ok(value)
 
-export const err = <T = never, E = unknown>(err: E): Err<T, E> => new Err(err)
+export function err<T = never, E extends string = string>(err: E): Err<T, E>
+export function err<T = never, E = unknown>(err: E): Err<T, E>
+export function err<T = never, E = unknown>(err: E): Err<T, E> {
+  return new Err(err)
+}
 
 /**
  * Evaluates the given generator to a Result returned or an Err yielded from it,

--- a/tests/typecheck-tests.ts
+++ b/tests/typecheck-tests.ts
@@ -338,11 +338,11 @@ type CreateTuple<L, V = string> =
     });
 
     (function it(_ = 'combines only err results into one') {
-      type Expectation = Result<[ never, never ], number | string>;
+      type Expectation = Result<[ never, never ], number | 'abc'>;
 
       const result = Result.combine([
         err(1),
-        err('string'),
+        err('abc'),
       ]);
 
       const assignableToCheck: Expectation = result;
@@ -928,7 +928,7 @@ type CreateTuple<L, V = string> =
     });
 
     (function it(_ = 'combines only err results into one') {
-      type Expectation = Result<[ never, never ], [number, string]>;
+      type Expectation = Result<[ never, never ], [number, 'string']>;
 
       const result = Result.combineWithAllErrors([
         err(1),
@@ -999,6 +999,24 @@ type CreateTuple<L, V = string> =
       });
     });
   });
+
+  (function describe(_ = 'err') {
+    (function it(_ = 'infers the error type narrowly when it is a string') {
+      type Expectation = Result<never, 'error'>
+
+      const result = err('error')
+
+      const assignableToCheck: Expectation = result;
+    });
+
+    (function it(_ = 'infers the error type widely when it is not a string') {
+      type Expectation = Result<never, { abc: number }>
+
+      const result = err({ abc: 123 })
+
+      const assignableToCheck: Expectation = result;
+    });
+  })
 });
 
 


### PR DESCRIPTION
I would like `err` to infer strings more narrowly. This would make it easier to create unions out of possible string errors.

```ts
const example = (num: number) => {
  if (num < 0) return err('Too low');
  if (num > 100) return err('Too high');

  return ok(num);
}
```

This would infer as `Ok<number> | Err<'Too low'> | Err<'Too high'>`.

Let me know if this is desirable.