### PR TITLE
chore: add a missing changeset file

### DIFF
--- a/.changeset/mighty-pans-promise.md
+++ b/.changeset/mighty-pans-promise.md
@@ -1,0 +1,5 @@
+---
+'neverthrow': minor
+---
+
+feat: add `andTee` and `andThrough` to handle side-effect


### PR DESCRIPTION
added a changeset file for #467 

⚠️After this PR is merged, CHANGELOG in the release PR will be updated like [this](https://github.com/supermacro/neverthrow/pull/566/files?w=1#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7). However, the author of changes of #467 will be the one who added the changeset file, which means **me**.
So please don't merge the release PR until I rewrite the author manually
