### PR TITLE
prevent passing a specific error type for `.fromThrowable` without providing an error mapping function

### DIFF
--- a/.changeset/grumpy-hats-unite.md
+++ b/.changeset/grumpy-hats-unite.md
@@ -1,0 +1,5 @@
+---
+'neverthrow': minor
+---
+
+prevent passing a specific error type for `.fromThrowable` without providing an error mapping function

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -43,16 +43,25 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static fromThrowable<A extends readonly any[], R>(
+    fn: (...args: A) => Promise<R>,
+  ): (...args: A) => ResultAsync<R, unknown>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static fromThrowable<A extends readonly any[], R, E>(
+    fn: (...args: A) => Promise<R>,
+    errorFn: (err: unknown) => E,
+  ): (...args: A) => ResultAsync<R, E>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static fromThrowable<A extends readonly any[], R, E>(
     fn: (...args: A) => Promise<R>,
     errorFn?: (err: unknown) => E,
-  ): (...args: A) => ResultAsync<R, E> {
+  ): (...args: A) => ResultAsync<R, E | unknown> {
     return (...args) => {
       return new ResultAsync(
         (async () => {
           try {
             return new Ok(await fn(...args))
-          } catch (error) {
+          } catch (error: unknown) {
             return new Err(errorFn ? errorFn(error) : error)
           }
         })(),

--- a/src/result.ts
+++ b/src/result.ts
@@ -17,18 +17,33 @@ export namespace Result {
    * arguments but returning `Ok` if successful, `Err` if the function throws
    *
    * @param fn function to wrap with ok on success or err on failure
-   * @param errorFn when an error is thrown, this will wrap the error result if provided
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function fromThrowable<Fn extends (...args: readonly any[]) => any>(
+    fn: Fn,
+  ): (...args: Parameters<Fn>) => Result<ReturnType<Fn>, unknown>
+  /**
+   * Wraps a function with a try catch, creating a new function with the same
+   * arguments but returning `Ok` if successful, `Err` if the function throws
+   *
+   * @param fn function to wrap with ok on success or err on failure
+   * @param errorFn when an error is thrown, this will wrap the error result
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export function fromThrowable<Fn extends (...args: readonly any[]) => any, E>(
     fn: Fn,
+    errorFn: (e: unknown) => E,
+  ): (...args: Parameters<Fn>) => Result<ReturnType<Fn>, E>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function fromThrowable<Fn extends (...args: readonly any[]) => any, E>(
+    fn: Fn,
     errorFn?: (e: unknown) => E,
-  ): (...args: Parameters<Fn>) => Result<ReturnType<Fn>, E> {
+  ): (...args: Parameters<Fn>) => Result<ReturnType<Fn>, E | unknown> {
     return (...args) => {
       try {
         const result = fn(...args)
         return ok(result)
-      } catch (e) {
+      } catch (e: unknown) {
         return err(errorFn ? errorFn(e) : e)
       }
     }


### PR DESCRIPTION
As discussed in https://github.com/supermacro/neverthrow/pull/567#discussion_r1754313850, the current type signature of `fromThrowable` allows users to pass a specific error value type, without providing an error mapping function that produces the provided error type:

```ts
const safeParse = Result.fromThrowable<typeof JSON.parse, number>(JSON.parse);
      // ^ (text: string, reviver?: (this: any, key: string, value: any) => any) => Result<any, number>
```

This PR tries to solve that by adding some overloads to the function, only allowing users to specify the error type when a matching error mapping function is provided.