### PR TITLE
Allow ok/err/okAsync/errAsync to accept zero arguments when returning void

### DIFF
--- a/.changeset/thirty-avocados-explain.md
+++ b/.changeset/thirty-avocados-explain.md
@@ -1,0 +1,5 @@
+---
+"neverthrow": minor
+---
+
+Allow ok/err/okAsync/errAsync to accept zero arguments when returning void

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -207,11 +207,17 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
   }
 }
 
-export const okAsync = <T, E = never>(value: T): ResultAsync<T, E> =>
-  new ResultAsync(Promise.resolve(new Ok<T, E>(value)))
+export function okAsync<T, E = never>(value: T): ResultAsync<T, E>
+export function okAsync<T extends void = void, E = never>(value: void): ResultAsync<void, E>
+export function okAsync<T, E = never>(value: T): ResultAsync<T, E> {
+  return new ResultAsync(Promise.resolve(new Ok<T, E>(value)))
+}
 
-export const errAsync = <T = never, E = unknown>(err: E): ResultAsync<T, E> =>
-  new ResultAsync(Promise.resolve(new Err<T, E>(err)))
+export function errAsync<T = never, E = unknown>(err: E): ResultAsync<T, E>
+export function errAsync<T = never, E extends void = void>(err: void): ResultAsync<T, void>
+export function errAsync<T = never, E = unknown>(err: E): ResultAsync<T, E> {
+  return new ResultAsync(Promise.resolve(new Err<T, E>(err)))
+}
 
 export const fromPromise = ResultAsync.fromPromise
 export const fromSafePromise = ResultAsync.fromSafePromise

--- a/src/result.ts
+++ b/src/result.ts
@@ -61,10 +61,15 @@ export namespace Result {
 
 export type Result<T, E> = Ok<T, E> | Err<T, E>
 
-export const ok = <T, E = never>(value: T): Ok<T, E> => new Ok(value)
+export function ok<T, E = never>(value: T): Ok<T, E>
+export function ok<T extends void = void, E = never>(value: void): Ok<void, E>
+export function ok<T, E = never>(value: T): Ok<T, E> {
+  return new Ok(value)
+}
 
 export function err<T = never, E extends string = string>(err: E): Err<T, E>
 export function err<T = never, E = unknown>(err: E): Err<T, E>
+export function err<T = never, E extends void = void>(err: void): Err<T, void>
 export function err<T = never, E = unknown>(err: E): Err<T, E> {
   return new Err(err)
 }


### PR DESCRIPTION
When implementing a function returning a result, it's often that I need to construct an `Ok<void>` object. However, it's not so ergonomic to do this. `ok` must be passed an argument, even if you explicitly specify the `void` type. This leads to passing a "dummy" value:

```ts
return ok<void>(undefined);
```

Meanwhile, in Promise-land, it's perfectly acceptable to call `Promise.resolve()` with no arguments, which returns a `Promise<void>`.

Interestingly, TS allows a parameter to be omitted if it has type `void`. However, this does not work if the type is generic and has been expanded to `void` or a union containing `void`. See https://github.com/Microsoft/TypeScript/issues/29131

This PR adds additional overloads for `ok`, `err`, `okAsync` and `errAsync` that separate out the case where the argument type is `void`. This allows the following to work as expected:

```ts
return ok<void>();
return ok();
```