### PR TITLE
feat: Add andFinally functionality and tests

### DIFF
--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -163,6 +163,23 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
     )
   }
 
+  andFinally<F>(f: () => ResultAsync<unknown, F> | Result<unknown, F>): ResultAsync<T, E | F> {
+    return new ResultAsync(
+      this._promise.then(
+        async (res) => {
+          const cleanupResult = await f()
+          return res.andFinally(() => cleanupResult)
+        },
+        async (err) => {
+          // this should be unreachable for well-behaved ResultAsync instances, but let's run the
+          // cleanup and propagate the erroneous rejection anyway
+          await f()
+          throw err
+        },
+      ),
+    )
+  }
+
   orElse<R extends Result<unknown, unknown>>(
     f: (e: E) => R,
   ): ResultAsync<InferOkTypes<R> | T, InferErrTypes<R>>

--- a/src/result.ts
+++ b/src/result.ts
@@ -204,6 +204,18 @@ interface IResult<T, E> {
   andThrough<F>(f: (t: T) => Result<unknown, F>): Result<T, E | F>
 
   /**
+   * Similar to a `finally` block in throw-based code. Runs the given callback
+   * regardless of whether the result is an `Ok` or an `Err`.
+   *
+   * This is useful for cleanup operations that should always be run regardless of an error.
+   *
+   * An `Ok` returned from the callback will always be ignored, while any `Err`
+   * returned from the callback will be returned and replace the original `Err`
+   * if there was one. .
+   */
+  andFinally<F>(f: () => Result<unknown, F>): Result<T, E | F>
+
+  /**
    * Takes an `Err` value and maps it to a `Result<T, SomeNewType>`.
    *
    * This is useful for error recovery.
@@ -330,6 +342,15 @@ export class Ok<T, E> implements IResult<T, E> {
     return ok<T, E>(this.value)
   }
 
+  andFinally<F>(cleanup: () => Result<unknown, F>): Result<T, E | F> {
+    const cleanupResult = cleanup()
+    if (cleanupResult.isErr()) {
+      return err(cleanupResult.error)
+    } else {
+      return this
+    }
+  }
+
   orElse<R extends Result<unknown, unknown>>(
     _f: (e: E) => R,
   ): Result<InferOkTypes<R> | T, InferErrTypes<R>>
@@ -418,6 +439,15 @@ export class Err<T, E> implements IResult<T, E> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   andThen(_f: any): any {
     return err(this.error)
+  }
+
+  andFinally<F>(cleanup: () => Result<unknown, F>): Result<T, E | F> {
+    const cleanupResult = cleanup()
+    if (cleanupResult.isErr()) {
+      return err(cleanupResult.error)
+    } else {
+      return this
+    }
   }
 
   orElse<R extends Result<unknown, unknown>>(


### PR DESCRIPTION
This PR is related to the earlier #536 which proposed an implementation for an `andFinally` method that will be called regardless of whether an earlier step contained an error or not. This would allow the caller to avoid awkward constructs which pass the same or similar callback to both `map`/`mapErr` or `andThen`/`orElse`.

The earlier implementation had some problems, and I believe the design still needed some considerations. Primarily, the earlier version did not allow for asynchronous cleanup logic which is a common use case for resources such as database connections, login sessions, etc.

The primary use case considered is one similar to the following. More broadly, the feature is designed to cover use cases that would be normally covered by the `finally` block in either synchronous or asynchronous code.

```ts

function createConnection(): ResultAsync<Connection, NetworkError | AuthenticationError> {
}
function doStuffWithConnection(connection: Connection): ResultAsync<void, NetworkError | BusinessLogicError> {
}
function terminateConnection(connection: Connection): ResultAsync<void, NetworkError> {
}

function main() {
    return createConnection().andThen(connection =>
        doStuffWithConnection(connection)
            // this will be called regardless of whether doStuffWithConnection errors or not
            .andFinally(connection => terminateConnection(connection))
    );
}

```


<h2> Design decisions </h2>

This feature was designed explicitly to handle scenarios which would normally be covered by the `finally` block in code that synchronously throws errors or uses `async/await`. This allows similar thought patterns easily apply to this library, and such code to more easily be updated to use `neverthrow`.

Key decisions are outlined below with further context.

<details>
<summary>
<h3> 1. The andFinally callback does not receive a parameter. </h3>
</summary>

In the `finally` block, I'm not aware of any languages that allow the programmer to directly check if an error has occurred or not. So, I elected not to pass any information about the earlier result to the callback. If it's absolutely necessary, the user can always use mutable state declared in an above scope just like they can with `finally`. (I rarely see this in practice).

Additionally, if the user wants to add separate logic for ok/error cases, I argue that we already have many features to do so `andThen`, `orElse`, etc.

I consider this decision to be low-risk since we can always add support for a `result` parameter to the callback without being a breaking change.
</details>

<details>
<summary>
<h3>2. ResultAsync.andFinally must return a Result/ResultAsync and `ok` values are ignored.</h3>
</summary>

In a normal `finally` block, it is possible for errors to be thrown. This is especially true in cases where a resource such as a database connection/transaction is used and the cleanup logic is asynchronous.

The most straightforward way to handle this is to require andFinally to return a Result. It also allows re-use of other functions that return Result/ResultAsync during cleanup. Other approaches require some kind of "sentinel" value to indicate that no error occurred.

OK values are ignored. This does diverge from languages which allow a `finally` block to contain a `return` statement, which will override any return value from elsewhere in the function. However, I do not recall seeing this used in practice.

</details>


<details>
<summary>
<h3>3. When andFinally returns an error, that error will propagate (and overwrite a previous error).</h3>
</summary>

I believe this is the most intuitive way to handle errors from `andFinally`. Firstly, it maps exactly to how `throw` is handled inside `finally`. 

If the user wants to ignore errors inside the callback, they are still free to explicitly ignore them, for example:

```ts
createConnection().andThen(connection =>
    connection.doStuff().andFinally(() =>
        connection.terminate().orElse((e) => {
            console.warn("Error terminating connection", e);
            return ok(undefined);
        })
    )
)
```

</details>

<details>
<summary>
<h3>4. Result.andFinally can return only a synchronous Result and not a ResultAsync.</h3>
</summary>

This decision was made partly to simplify the implementation and avoid the need for any overloads which can make it more difficult to ensure type-safe code.

In practice I would also expect that if a particular piece of cleanup logic is asynchronous, it is likely that the earlier steps' logic is also asynchronous. This would be the case for most use cases I can think of (database connections and other resource-based cleanup).

**Low-risk** since we can always add an overload that broadens the accepted types without breaking existing code.

If we feel it's important to continue adding support for `ResultAsync` in Result's methods, I propose that a better path forwards is to add a `.asAsync()` method to both Ok and Err that simply lifts the result into a `ResultAsync`. It's also trivial for the user to do the wrapping themselves.
</details>

<details>
<summary>
<h3>5. ResultAsync.andFinally will call the cleanup function even if the internal promise rejects</h3>
</summary>

Normally, we can make the assumption that ResultAsync's internal promise should only ever reject if someone is misusing the library (e.g. calling `fromSafePromise` or `new ResultAsync` with something that's not safe). I decided that the cleanup function should still be called in this case, but we still propagate the rejection.

My justification:
1. If an erroneous rejection occurs inside ResultAsync, it is indicative of a bug and if we don't run the cleanup function we are more likely to leave the whole application in a globally-broken state from the callers' perspective. (Resource leak, hanging database transaction, etc.). I believe the caller is more likely to want the cleanup to run.
2. We can well-define the contract of andFinally to include this feature and the caller will know it will happen.
3. If there are multiple andFinally blocks in the same chain, they will still all be called which is logically consistent.
4. The rejection is not silently absorbed but will instead propagate through the ResultAsync returned from andFinally, and the bug causing it to happen can still be discovered.

It is a little awkward that we can't do the same for synchronous Results since if an error is _thrown_ during an earlier step, the result whose `andFinally` method we are calling will never exist. A problem I can see is that the contract for Result/ResultAsync differs in this one aspect.
</details>