### PR TITLE
Add custom message to _unsafeUnwrap*

### DIFF
--- a/.changeset/hip-cycles-clean.md
+++ b/.changeset/hip-cycles-clean.md
@@ -1,0 +1,5 @@
+---
+'neverthrow': minor
+---
+
+Add custom message to \_unsafeUnwrap

--- a/README.md
+++ b/README.md
@@ -1571,9 +1571,17 @@ _unsafeUnwrapErr({
 
 // ^ Now the error object will have a `.stack` property containing the current stack
 ```
+You can also conditionally add a custom error message that will be propagated with the error object. By default this error message will be `Called '_unsafeUnwrap' on an Err` when called on an `Err` and `Called '_unsafeUnwrapErr' on an Ok` when called on an `Ok`.
+
+```typescript
+_unsafeUnwrapErr({
+  message: 'Your custom error message',
+  withStackTrace: true,
+})
+```
 
 ---
-
+  
 If you find this package useful, please consider [sponsoring me](https://github.com/sponsors/supermacro/) or simply [buying me a coffee](https://ko-fi.com/gdelgado)!
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neverthrow",
-  "version": "7.0.1",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neverthrow",
-      "version": "7.0.1",
+      "version": "8.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.24.7",

--- a/src/_internals/error.ts
+++ b/src/_internals/error.ts
@@ -1,7 +1,8 @@
 import { Result } from '../result'
 
 export interface ErrorConfig {
-  withStackTrace: boolean
+  withStackTrace?: boolean
+  message?: string
 }
 
 const defaultErrorConfig: ErrorConfig = {

--- a/src/result.ts
+++ b/src/result.ts
@@ -379,7 +379,11 @@ export class Ok<T, E> implements IResult<T, E> {
   }
 
   _unsafeUnwrapErr(config?: ErrorConfig): E {
-    throw createNeverThrowError('Called `_unsafeUnwrapErr` on an Ok', this, config)
+    throw createNeverThrowError(
+      config?.message ?? 'Called `_unsafeUnwrapErr` on an Ok',
+      this,
+      config,
+    )
   }
 }
 
@@ -461,7 +465,7 @@ export class Err<T, E> implements IResult<T, E> {
   }
 
   _unsafeUnwrap(config?: ErrorConfig): T {
-    throw createNeverThrowError('Called `_unsafeUnwrap` on an Err', this, config)
+    throw createNeverThrowError(config?.message ?? 'Called `_unsafeUnwrap` on an Err', this, config)
   }
 
   _unsafeUnwrapErr(_?: ErrorConfig): E {


### PR DESCRIPTION
### Pull Request Description

#### Summary
This PR introduces enhancements to the error handling mechanism within the codebase by allowing custom error messages to be specified. Additionally, it updates the README documentation and adds new test cases.

#### Changes Made
1. **README.md**:
   - Added documentation on how to conditionally add a custom error message that will propagate with the error object.
   - Provided an example to demonstrate the usage of the custom error message with a stack trace.

2. **`src/_internals/error.ts`**:
   - Updated the `ErrorConfig` interface to include an optional `message` property.

3. **`src/result.ts`**:
   - Modified the `_unsafeUnwrapErr` method in the `Ok` class to use the custom error message if provided, otherwise, it defaults to the existing message.
   - Updated the `_unsafeUnwrap` method in the `Err` class to use the custom error message if provided, otherwise, it defaults to the existing message.

4. **`tests/index.test.ts`**:
   - Added test cases to verify that custom error messages are correctly included when `_unsafeUnwrap` and `_unsafeUnwrapErr` are called with a custom message in the `Ok` and `Err` classes.
