### PR TITLE
feat: add `ResultValue` and `ResultError` helper types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
-export { Result, ok, Ok, err, Err, fromThrowable, safeTry } from './result'
+export { Err, Ok, Result, err, fromThrowable, ok, safeTry } from './result'
 export {
   ResultAsync,
-  okAsync,
   errAsync,
   fromAsyncThrowable,
   fromPromise,
   fromSafePromise,
+  okAsync,
 } from './result-async'
+export type { ResultError } from './result-error'
+export type { ResultValue } from './result-value'

--- a/src/result-error.ts
+++ b/src/result-error.ts
@@ -1,0 +1,12 @@
+import { Result } from 'result'
+import { ResultAsync } from 'result-async'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ResultError<T extends Result<any, any> | ResultAsync<any, any>> = T extends Result<
+  infer _,
+  infer E
+>
+  ? E
+  : T extends ResultAsync<infer _, infer E>
+  ? E
+  : never

--- a/src/result-value.ts
+++ b/src/result-value.ts
@@ -1,0 +1,12 @@
+import { Result } from 'result'
+import { ResultAsync } from 'result-async'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ResultValue<T extends Result<any, any> | ResultAsync<any, any>> = T extends Result<
+  infer U,
+  infer _
+>
+  ? U
+  : T extends ResultAsync<infer U, infer _>
+  ? U
+  : never


### PR DESCRIPTION
Hi,

I've been enjoying neverthrow for a while now. Since I try to rely on type inference as much as possible, I used some version of the types added in this PR in each project I used neverthrow in. Basically, they allow using this pattern:

```ts
function createSomething(): Result<{ name: string }, Error> {
  return ok({ name: 'John' })
}

function useSomething(something: ResultValue<ReturnType<typeof createSomething>>) {
  console.log(something.name)
}
```

Even better would be a version that would allow something like:

```ts
function createSomething() {
  if (somethingRandom()) {
    return err(new Error())
  }

  return ok({ name: 'John' })
}

function useSomething(something: ResultValue<ReturnType<typeof createSomething>>) {
  console.log(something.name)
}
```

But I couldn't figure out a straightforward way to achieve this (maybe @mattpocock could help). I would love to see these added, as not every TS developer knows how to use TS features like conditional types and infer, and having them be part of the library could encourage more developers to rely on type inference.