### PR TITLE
Update README to not require safeUnwrap after 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,7 +802,7 @@ const result = Result.combineWithAllErrors(resultList)
 
 #### `Result.safeUnwrap()`
 
-**⚠️ You must use `.safeUnwrap` in a generator context with `safeTry`**. Please see [safeTry](#safeTry).
+**⚠️ If you are using version 8.0.0 or earlier, you must use `.safeUnwrap` in a generator context with `safeTry`**. Please see [safeTry](#safeTry).
 
 Allows for unwrapping a `Result` or returning an `Err` implicitly, thereby reducing boilerplate.
 
@@ -1412,7 +1412,7 @@ const result = ResultAsync.combineWithAllErrors(resultList)
 
 #### `ResultAsync.safeUnwrap()`
 
-**⚠️ You must use `.safeUnwrap` in a generator context with `safeTry`**. Please see [safeTry](#safeTry).
+**⚠️ If you are using version 8.0.0 or earlier, you must use `.safeUnwrap` in a generator context with `safeTry`**. Please see [safeTry](#safeTry).
 
 Allows for unwrapping a `Result` or returning an `Err` implicitly, thereby reducing boilerplate.
 
@@ -1493,12 +1493,12 @@ function myFunc(): Result<number, string> {
             // Otherwise, this `(yield* ...)` is evaluated to its `.value`.
             (yield* mayFail1()
                 .mapErr(e => `aborted by an error from 1st function, ${e}`)
-                .safeUnwrap())
+                // .safeUnwrap()) ⚠️ You must use this for version 8.0.0 or earlier
             +
             // The same as above.
             (yield* mayFail2()
                 .mapErr(e => `aborted by an error from 2nd function, ${e}`)
-                .safeUnwrap())
+                // .safeUnwrap()) ⚠️ You must use this for version 8.0.0 or earlier
         )
     })
 }
@@ -1521,12 +1521,12 @@ function myFunc(): Promise<Result<number, string>> {
             // You have to await if the expression is Promise<Result>
             (yield* (await mayFail1())
                 .mapErr(e => `aborted by an error from 1st function, ${e}`)
-                .safeUnwrap())
+                // .safeUnwrap()) ⚠️ You must use this for version 8.0.0 or earlier
             +
             // You can call `safeUnwrap` directly if its ResultAsync
             (yield* mayFail2()
                 .mapErr(e => `aborted by an error from 2nd function, ${e}`)
-                .safeUnwrap())
+                // .safeUnwrap()) ⚠️ You must use this for version 8.0.0 or earlier
         )
     })
 }


### PR DESCRIPTION
After [this](https://github.com/supermacro/neverthrow/releases/tag/v8.1.0) release, the docs became slightly outdated.

This PR adds notices that it only applies for version 8.0.0 and earlier