### PR TITLE
feat: Add andInspectErr method

### DIFF
--- a/.changeset/fast-zebras-end.md
+++ b/.changeset/fast-zebras-end.md
@@ -1,0 +1,5 @@
+---
+'neverthrow': minor
+---
+
+Add andInspectErr method

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -130,6 +130,22 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
     )
   }
 
+  andInspectErr(f: (e: E) => unknown): ResultAsync<T, E> {
+    return new ResultAsync(
+      this._promise.then(async (res: Result<T, E>) => {
+        if (res.isOk()) {
+          return new Ok<T, E>(res.value)
+        }
+        try {
+          await f(res.error)
+        } catch (e) {
+          // InspectErr does not care about the error
+        }
+        return new Err<T, E>(res.error)
+      }),
+    )
+  }
+
   mapErr<U>(f: (e: E) => U | Promise<U>): ResultAsync<T, U> {
     return new ResultAsync(
       this._promise.then(async (res: Result<T, E>) => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -159,6 +159,29 @@ describe('Result.Ok', () => {
     })
   })
 
+  describe('andInspectErr', () => {
+    it('Skips over andInspectErr for Ok Result', () => {
+      const okVal = ok(12)
+      const passedFn = vitest.fn((_number) => {})
+
+      const inspected = okVal.andInspectErr(passedFn)
+
+      expect(inspected.isOk()).toBe(true)
+      expect(passedFn).not.toHaveBeenCalled()
+      expect(inspected._unsafeUnwrap()).toBe(12)
+    })
+    it('Skips over andInspectErr for Ok ResultAsync', async () => {
+      const okVal = okAsync(12)
+      const passedFn = vitest.fn((_number) => {})
+
+      const inspected = await okVal.andInspectErr(passedFn)
+
+      expect(inspected.isOk()).toBe(true)
+      expect(passedFn).not.toHaveBeenCalled()
+      expect(inspected._unsafeUnwrap()).toBe(12)
+    })
+  })
+
   describe('asyncAndThrough', () => {
     it('Calls the passed function but returns an original ok as Async', async () => {
       const okVal = ok(12)
@@ -358,6 +381,57 @@ describe('Result.Err', () => {
     expect(hopefullyNotFlattened.isErr()).toBe(true)
     expect(mapper).not.toHaveBeenCalled()
     expect(errVal._unsafeUnwrapErr()).toEqual('Yolo')
+  })
+
+  describe('andInspectErr', () => {
+    it('Calls the passed function but returns an original err value', async () => {
+      const errVal = err('oops')
+      const passedFn = vitest.fn((_string) => {
+        return err('new error')
+      })
+
+      const inspected = errVal.andInspectErr(passedFn)
+
+      expect(inspected.isErr()).toBe(true)
+      expect(passedFn).toHaveBeenCalledTimes(1)
+      expect(inspected._unsafeUnwrapErr()).toBe('oops')
+    })
+    it('Calls the passed function but returns an original async err value', async () => {
+      const errVal = errAsync('oops')
+      const passedFn = vitest.fn((_string) => {
+        return errAsync('new error')
+      })
+
+      const inspected = await errVal.andInspectErr(passedFn)
+
+      expect(inspected.isErr()).toBe(true)
+      expect(passedFn).toHaveBeenCalledTimes(1)
+      expect(inspected._unsafeUnwrapErr()).toBe('oops')
+    })
+    it('returns an original err even when the passed function fails', async () => {
+      const errVal = err('original error')
+      const passedFn = vitest.fn((_string) => {
+        throw new Error('OMG!')
+      })
+
+      const inspected = errVal.andInspectErr(passedFn)
+
+      expect(inspected.isErr()).toBe(true)
+      expect(passedFn).toHaveBeenCalledTimes(1)
+      expect(inspected._unsafeUnwrapErr()).toBe('original error')
+    })
+    it('returns an original async err even when the passed function fails', async () => {
+      const errVal = errAsync('original error')
+      const passedFn = vitest.fn((_string) => {
+        throw new Error('OMG!')
+      })
+
+      const inspected = await errVal.andInspectErr(passedFn)
+
+      expect(inspected.isErr()).toBe(true)
+      expect(passedFn).toHaveBeenCalledTimes(1)
+      expect(inspected._unsafeUnwrapErr()).toBe('original error')
+    })
   })
 
   it('Skips over asyncAndThrough but returns ResultAsync instead', async () => {
@@ -1040,6 +1114,31 @@ describe('ResultAsync', () => {
   })
 
   describe('andTee', () => {
+    it('Calls the passed function but returns an original ok', async () => {
+      const okVal = okAsync(12)
+      const passedFn = vitest.fn((_number) => {})
+
+      const teed = await okVal.andTee(passedFn)
+
+      expect(teed.isOk()).toBe(true)
+      expect(passedFn).toHaveBeenCalledTimes(1)
+      expect(teed._unsafeUnwrap()).toStrictEqual(12)
+    })
+    it('returns an original ok even when the passed function fails', async () => {
+      const okVal = okAsync(12)
+      const passedFn = vitest.fn((_number) => {
+        throw new Error('OMG!')
+      })
+
+      const teed = await okVal.andTee(passedFn)
+
+      expect(teed.isOk()).toBe(true)
+      expect(passedFn).toHaveBeenCalledTimes(1)
+      expect(teed._unsafeUnwrap()).toStrictEqual(12)
+    })
+  })
+
+  describe('andInspectErr', () => {
     it('Calls the passed function but returns an original ok', async () => {
       const okVal = okAsync(12)
       const passedFn = vitest.fn((_number) => {})


### PR DESCRIPTION
Hi! Thanks a lot for the library, I am enjoying using it a lot! 🥇 

This PR adds a new method called `andInspectErr` similar to [`inspect_err`](https://doc.rust-lang.org/std/result/enum.Result.html#method.inspect_err) we have in rust.