### PR TITLE
Add orTee method to tee the error track

### DIFF
--- a/.changeset/tender-impalas-refuse.md
+++ b/.changeset/tender-impalas-refuse.md
@@ -1,0 +1,5 @@
+---
+'neverthrow': minor
+---
+
+Add orTee, which is the equivalent of andTee but for the error track.

--- a/src/result-async.ts
+++ b/src/result-async.ts
@@ -130,6 +130,22 @@ export class ResultAsync<T, E> implements PromiseLike<Result<T, E>> {
     )
   }
 
+  orTee(f: (t: E) => unknown): ResultAsync<T, E> {
+    return new ResultAsync(
+      this._promise.then(async (res: Result<T, E>) => {
+        if (res.isOk()) {
+          return new Ok<T, E>(res.value)
+        }
+        try {
+          await f(res.error)
+        } catch (e) {
+          // Tee does not care about the error
+        }
+        return new Err<T, E>(res.error)
+      }),
+    )
+  }
+
   mapErr<U>(f: (e: E) => U | Promise<U>): ResultAsync<T, U> {
     return new ResultAsync(
       this._promise.then(async (res: Result<T, E>) => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -195,6 +195,18 @@ interface IResult<T, E> {
   andTee(f: (t: T) => unknown): Result<T, E>
 
   /**
+   * This "tee"s the current `Err` value to an passed-in computation such as side
+   * effect functions but still returns the same `Err` value as the result.
+   *
+   * This is useful when you want to pass the current `Err` value to your side-track
+   * work such as logging but want to continue error-track work after that.
+   * This method does not care about the result of the passed in computation.
+   *
+   * @param f The function to apply to the current `Err` value
+   */
+  orTee(f: (t: E) => unknown): Result<T, E>
+
+  /**
    * Similar to `andTee` except error result of the computation will be passed
    * to the downstream in case of an error.
    *
@@ -342,6 +354,10 @@ export class Ok<T, E> implements IResult<T, E> {
     return ok<T, E>(this.value)
   }
 
+  orTee(_f: (t: E) => unknown): Result<T, E> {
+    return ok<T, E>(this.value)
+  }
+
   orElse<R extends Result<unknown, unknown>>(
     _f: (e: E) => R,
   ): Result<InferOkTypes<R> | T, InferErrTypes<R>>
@@ -426,6 +442,15 @@ export class Err<T, E> implements IResult<T, E> {
 
   andTee(_f: (t: T) => unknown): Result<T, E> {
     return err(this.error)
+  }
+
+  orTee(f: (t: E) => unknown): Result<T, E> {
+    try {
+      f(this.error)
+    } catch (e) {
+      // Tee doesn't care about the error
+    }
+    return err<T, E>(this.error)
   }
 
   andThen<R extends Result<unknown, unknown>>(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -159,6 +159,31 @@ describe('Result.Ok', () => {
     })
   })
 
+  describe('orTee', () => {
+    it('Calls the passed function but returns an original err', () => {
+      const errVal = err(12)
+      const passedFn = vitest.fn((_number) => {})
+
+      const teed = errVal.orTee(passedFn)
+
+      expect(teed.isErr()).toBe(true)
+      expect(passedFn).toHaveBeenCalledTimes(1)
+      expect(teed._unsafeUnwrapErr()).toStrictEqual(12)
+    })
+    it('returns an original err even when the passed function fails', () => {
+      const errVal = err(12)
+      const passedFn = vitest.fn((_number) => {
+        throw new Error('OMG!')
+      })
+
+      const teed = errVal.orTee(passedFn)
+
+      expect(teed.isErr()).toBe(true)
+      expect(passedFn).toHaveBeenCalledTimes(1)
+      expect(teed._unsafeUnwrapErr()).toStrictEqual(12)
+    })
+  })
+
   describe('asyncAndThrough', () => {
     it('Calls the passed function but returns an original ok as Async', async () => {
       const okVal = ok(12)
@@ -1061,6 +1086,31 @@ describe('ResultAsync', () => {
       expect(teed.isOk()).toBe(true)
       expect(passedFn).toHaveBeenCalledTimes(1)
       expect(teed._unsafeUnwrap()).toStrictEqual(12)
+    })
+  })
+
+  describe('orTee', () => {
+    it('Calls the passed function but returns an original err', async () => {
+      const errVal = errAsync(12)
+      const passedFn = vitest.fn((_number) => {})
+
+      const teed = await errVal.orTee(passedFn)
+
+      expect(teed.isErr()).toBe(true)
+      expect(passedFn).toHaveBeenCalledTimes(1)
+      expect(teed._unsafeUnwrapErr()).toStrictEqual(12)
+    })
+    it('returns an original err even when the passed function fails', async () => {
+      const errVal = errAsync(12)
+      const passedFn = vitest.fn((_number) => {
+        throw new Error('OMG!')
+      })
+
+      const teed = await errVal.orTee(passedFn)
+
+      expect(teed.isErr()).toBe(true)
+      expect(passedFn).toHaveBeenCalledTimes(1)
+      expect(teed._unsafeUnwrapErr()).toStrictEqual(12)
     })
   })
 


### PR DESCRIPTION
Add a method for both `Result` and `ResultAsync` to tee the error track.

I now see that it's very similar to #612 , so at least this can be considered a +1 :)
