### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For asynchronous tasks, `neverthrow` offers a `ResultAsync` class which wraps a 
 ## Installation
 
 ```sh
-> npm install neverthrow
+npm install neverthrow
 ```
 
 ## Recommended: Use `eslint-plugin-neverthrow`
@@ -83,7 +83,7 @@ As part of `neverthrow`s [bounty program](https://github.com/supermacro/neverthr
 Install by running:
 
 ```sh
-> npm install eslint-plugin-neverthrow
+npm install eslint-plugin-neverthrow
 ```
 
 With `eslint-plugin-neverthrow`, you are forced to consume the result in one of the following three ways:


### PR DESCRIPTION
The goal of this change is to remove the `> ` from the npm install commands in the README that break the quick copy/paste feature that GitHub now offers.

We should copy only `npm install...` without the `> ` because doing so won't let us execute the command on paste.

A small change that will have a big impact in productivity :)