### PR TITLE
Add toJSON methdo for serialization. 

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -147,6 +147,15 @@ interface IResult<T, E> {
   isErr(): this is Err<T, E>
 
   /**
+   * This function is used by `JSON.stringify` to serialize the result
+   * without loosing isOk and isErr by turning them into booleans
+   *
+   * @returns `{ error, isOk, isErr }` if the result is an `Err` variant
+   * and { value, isOk, isErr } if the result is `Ok` variant
+   */
+  toJSON(): unknown
+
+  /**
    * Maps a `Result<T, E>` to `Result<U, E>`
    * by applying a function to a contained `Ok` value, leaving an `Err` value
    * untouched.
@@ -320,6 +329,14 @@ export class Ok<T, E> implements IResult<T, E> {
     return !this.isOk()
   }
 
+  toJSON(): unknown {
+    return {
+      value: this.value,
+      isOk: this.isOk(),
+      isErr: this.isErr(),
+    }
+  }
+
   map<A>(f: (t: T) => A): Result<A, E> {
     return ok(f(this.value))
   }
@@ -425,6 +442,14 @@ export class Err<T, E> implements IResult<T, E> {
 
   isErr(): this is Err<T, E> {
     return !this.isOk()
+  }
+
+  toJSON(): unknown {
+    return {
+      error: this.error,
+      isOk: this.isOk(),
+      isErr: this.isErr(),
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -67,6 +67,16 @@ describe('Result.Ok', () => {
     expect(mapErrorFunc).not.toHaveBeenCalledTimes(1)
   })
 
+  it('Stringifies and parses correctly', () => {
+    const okVal = ok(12)
+    
+    const parsedJSON = JSON.parse(JSON.stringify(okVal))
+    
+    expect(parsedJSON.isOk).toBe(true)
+    expect(parsedJSON.isErr).toBe(false)
+    expect(parsedJSON.value).toBe(12)
+  })
+
   describe('andThen', () => {
     it('Maps to an Ok', () => {
       const okVal = ok(12)
@@ -330,6 +340,16 @@ describe('Result.Err', () => {
     expect(hopefullyNotMapped.isErr()).toBe(true)
     expect(mapper).not.toHaveBeenCalled()
     expect(hopefullyNotMapped._unsafeUnwrapErr()).toEqual(errVal._unsafeUnwrapErr())
+  })
+
+  it('Stringifies and parses correctly', () => {
+    const errVal = err('I am your father')
+    
+    const parsedJSON = JSON.parse(JSON.stringify(errVal))
+    
+    expect(parsedJSON.isOk).toBe(false)
+    expect(parsedJSON.isErr).toBe(true)
+    expect(parsedJSON.error).toBe('I am your father')
   })
 
   it('Maps over an Err', () => {


### PR DESCRIPTION
Since `ok` and `err` are classes, when they're returned from server action to a client component the result would loose all methods including `isOk` and `isErr`.

This PR is related to the issue #628 

I am thinking of adding the same way to `ResultAsync` but then on client it would become just like `Result``.

This currenly includes `value` in case of Ok and `error` in case of Err, `isOk` and `isErr` booleans.