### PR TITLE
Ensure that `createNeverThrowError` throws an Error that is an instance of `Error` class.

### DIFF
--- a/src/_internals/error.ts
+++ b/src/_internals/error.ts
@@ -8,18 +8,32 @@ const defaultErrorConfig: ErrorConfig = {
   withStackTrace: false,
 }
 
-interface NeverThrowError<T, E> {
-  data:
-    | {
-        type: string
-        value: T
-      }
-    | {
-        type: string
-        value: E
-      }
-  message: string
-  stack: string | undefined
+type ErrorData<T, E> = {
+  type: string
+  value: T
+} | {
+  type: string
+  value: E
+}
+
+class NeverThrowError<T, E> extends Error {
+  data: ErrorData<T, E>
+
+  constructor({
+    data,
+    message,
+    stack,
+  }: {
+    data: ErrorData<T, E>
+    message: string
+    stack: string | undefined
+  }) {
+    super();
+    this.data = data;
+    this.message = message;
+    this.stack = stack;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
 }
 
 // Custom error object
@@ -35,9 +49,9 @@ export const createNeverThrowError = <T, E>(
 
   const maybeStack = config.withStackTrace ? new Error().stack : undefined
 
-  return {
+  return new NeverThrowError<T, E>({
     data,
     message,
     stack: maybeStack,
-  }
+  })
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -42,6 +42,12 @@ describe('Result.Ok', () => {
     expect(okVal._unsafeUnwrap()).toBeUndefined()
   })
 
+  it('Throws an error that is an instance of error', () => {
+    const okVal = ok(undefined)
+
+    expect(() => okVal._unsafeUnwrapErr()).toThrowError(Error);
+  });
+
   it('Is comparable', () => {
     expect(ok(42)).toEqual(ok(42))
     expect(ok(42)).not.toEqual(ok(43))


### PR DESCRIPTION
Internally at Google, we have some company-wide conformance tests that ensure that all errors that are thrown, are subclasses of `Error`.

To ensure this, I adjusted the `createNeverThrowError` func to return a new `NeverThrowError` class, which both extends `Error` and overwrites the object's prototype to ensure that it is `Error`.

This allows for:

```
createNeverThrowError(...) instanceOf Error
> true
```

`createNeverThrowError` feels like an internal detail of the library and is only used in some fringe boundary cases.  I added a quick test in a spot that felt the most obvious. Suggestions on alternatives are welcome!