### PR TITLE
docs: fix typo in readme example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,7 +675,7 @@ const resAsync = parseUserInput(userInput)
                .andThrough(validateUser)
                .asyncAndThen(insertUser)
 
-resAsync.then((res: Result<void, ParseErro | ValidateError | InsertError>) => {
+resAsync.then((res: Result<void, ParseError | ValidateError | InsertError>) => {
   if(res.isErr()){
     console.log("Oops, at least one step failed", res.error)
   }


### PR DESCRIPTION
Updates `ParseErro` to be `ParseError` in README.md example code for the async `.andThrough()`

Let me know if I need to make an issue, but I figured this was small enough.