### PR TITLE
Update README.md to fix an error in `orTee` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1357,7 +1357,7 @@ import { sendNotification } from 'imaginary-service'
 // Note logInsertError returns void on success but sendNotification takes User type. 
 
 const resAsync = insertUser(user)
-                .orTee(logUser)
+                .orTee(logInsertError)
                 .andThen(sendNotification)
 
 // Note there is no LogError in the types below 


### PR DESCRIPTION
Found a typo in the README while evaluating, so I thought I'd send a fix over.