### PR TITLE
docs: fix async map anchor links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For asynchronous tasks, `neverthrow` offers a `ResultAsync` class which wraps a 
     - [`Result.asyncAndThen` (method)](#resultasyncandthen-method)
     - [`Result.orElse` (method)](#resultorelse-method)
     - [`Result.match` (method)](#resultmatch-method)
-    - [`Result.asyncMap` (method)](#resultasyncmap-method)
+    - [`Result.asyncMap` (method)](#result-asyncmap-method)
     - [`Result.andTee` (method)](#resultandtee-method)
     - [`Result.orTee` (method)](#resultortee-method)
     - [`Result.andThrough` (method)](#resultandthrough-method)
@@ -49,7 +49,7 @@ For asynchronous tasks, `neverthrow` offers a `ResultAsync` class which wraps a 
     - [`ResultAsync.fromThrowable` (static class method)](#resultasyncfromthrowable-static-class-method)
     - [`ResultAsync.fromPromise` (static class method)](#resultasyncfrompromise-static-class-method)
     - [`ResultAsync.fromSafePromise` (static class method)](#resultasyncfromsafepromise-static-class-method)
-    - [`ResultAsync.map` (method)](#resultasyncmap-method)
+    - [`ResultAsync.map` (method)](#resultasync-map-method)
     - [`ResultAsync.mapErr` (method)](#resultasyncmaperr-method)
     - [`ResultAsync.unwrapOr` (method)](#resultasyncunwrapor-method)
     - [`ResultAsync.andThen` (method)](#resultasyncandthen-method)
@@ -511,6 +511,7 @@ const answer = computationThatMightFail()
 
 ---
 
+<a id="result-asyncmap-method"></a>
 #### `Result.asyncMap` (method)
 
 Similar to `map` except for two things:
@@ -1038,6 +1039,7 @@ export const signupHandler = route<User>((req, sessionManager) =>
 
 ---
 
+<a id="resultasync-map-method"></a>
 #### `ResultAsync.map` (method)
 
 Maps a `ResultAsync<T, E>` to `ResultAsync<U, E>` by applying a function to a contained `Ok` value, leaving an `Err` value untouched.


### PR DESCRIPTION
Currently, the link in the README outline to `ResultAsync.map` is broken: it links to `Result.asyncMap`.

This is because GitHub markdown automatically creates anchor IDs for headings by lower-casing and stripping down the heading text of any non alphanumeric characters. So `Result.asyncMap` and `ResultAsync.map` reduce to the same anchor ID.

This gives each heading a unique anchor ID to fix the link.