### PR TITLE
Add `this` context support to `safeTry` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1582,7 +1582,7 @@ declare function mayFail1(): Result<number, string>;
 declare function mayFail2(): Result<number, string>;
 
 function myFunc(): Result<number, string> {
-    return safeTry<number, string>(function*() {
+    return safeTry(function*() {
         return ok(
             // If the result of mayFail1().mapErr() is an `Err`, the evaluation is
             // aborted here and the enclosing `safeTry` block is evaluated to that `Err`.
@@ -1610,8 +1610,8 @@ You can also use [async generator function](https://developer.mozilla.org/en-US/
 declare function mayFail1(): Promise<Result<number, string>>;
 declare function mayFail2(): ResultAsync<number, string>;
 
-function myFunc(): Promise<Result<number, string>> {
-    return safeTry<number, string>(async function*() {
+function myFunc(): ResultAsync<number, string> {
+    return safeTry(async function*() {
         return ok(
             // You have to await if the expression is Promise<Result>
             (yield* (await mayFail1())

--- a/README.md
+++ b/README.md
@@ -1603,7 +1603,8 @@ To use `safeTry`, the points are as follows.
 * In that block, you can use `yield* <RESULT>` to state 'Return `<RESULT>` if it's an `Err`, otherwise evaluate to its `.value`'
 * Pass the generator function to `safeTry`
 
-You can also use [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to pass an async block to `safeTry`.
+You can also use [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*) to pass an async block to `safeTry`. For more information, see https://github.com/supermacro/neverthrow/pull/448 and https://github.com/supermacro/neverthrow/issues/444
+
 ```typescript
 // You can use either Promise<Result> or ResultAsync.
 declare function mayFail1(): Promise<Result<number, string>>;
@@ -1624,7 +1625,26 @@ function myFunc(): Promise<Result<number, string>> {
 }
 ```
 
-For more information, see https://github.com/supermacro/neverthrow/pull/448 and https://github.com/supermacro/neverthrow/issues/444
+Additionally, when using `safeTry` in class methods, you can pass `this` context as the first argument:
+
+```typescript
+class MyClass {
+  mayFail1: () => Promise<Result<number, string>>;
+  mayFail2: () => ResultAsync<number, string>;
+
+  myFunc(): ResultAsync<number, string> {
+    return safeTry(this, async function*() {
+        return ok(
+            (yield* (await this.mayFail1())
+                .mapErr(e => `aborted by an error from 1st function, ${e}`))
+            +
+            (yield* this.mayFail2()
+                .mapErr(e => `aborted by an error from 2nd function, ${e}`))
+        )
+    })
+  }
+}
+```
 
 [⬆️  Back to top](#toc)
 

--- a/tests/safe-try.test.ts
+++ b/tests/safe-try.test.ts
@@ -23,9 +23,25 @@ describe('Returns what is returned from the generator function', () => {
     expect(res._unsafeUnwrap()).toBe(val)
   })
 
+  test("With synchronous Ok and this context", () => {
+    const res = safeTry(val, function*() {
+      return ok(this)
+    })
+    expect(res).toBeInstanceOf(Ok)
+    expect(res._unsafeUnwrap()).toBe(val)
+  })
+
   test("With synchronous Err", () => {
     const res = safeTry(function*() {
       return err(val)
+    })
+    expect(res).toBeInstanceOf(Err)
+    expect(res._unsafeUnwrapErr()).toBe(val)
+  })
+
+  test("With synchronous Err and this context", () => {
+    const res = safeTry(val, function*() {
+      return err(this)
     })
     expect(res).toBeInstanceOf(Err)
     expect(res._unsafeUnwrapErr()).toBe(val)
@@ -39,9 +55,25 @@ describe('Returns what is returned from the generator function', () => {
     expect(res._unsafeUnwrap()).toBe(val)
   })
 
+  test("With async Ok and this context", async () => {
+    const res = await safeTry(val, async function*() {
+      return await okAsync(this)
+    })
+    expect(res).toBeInstanceOf(Ok)
+    expect(res._unsafeUnwrap()).toBe(val)
+  })
+
   test("With async Err", async () => {
     const res = await safeTry(async function*() {
       return await errAsync(val)
+    })
+    expect(res).toBeInstanceOf(Err)
+    expect(res._unsafeUnwrapErr()).toBe(val)
+  })
+
+  test("With async Err and this context", async () => {
+    const res = await safeTry(val, async function*() {
+      return await errAsync(this)
     })
     expect(res).toBeInstanceOf(Err)
     expect(res._unsafeUnwrapErr()).toBe(val)


### PR DESCRIPTION
This PR implements support for passing `this` context to the generator function in `safeTry`, following the established pattern already implemented in similar libraries like [Effect](https://effect.website/docs/getting-started/using-generators/#passing-this) and [typescript-result](https://www.typescript-result.dev/chaining-vs-generator-syntax#this-context).

Closes #632

### Usage

```typescript
class MyClass {
  private multiplier = 2;
  
  getValue(): number {
    return 10;
  }
  
  myMethod(): Result<number, string> {
    return safeTry(this, function* () {
      const value = this.getValue();
      return ok(value * this.multiplier);
    });
  }
}
```

### Why This Matters

This feature enhances the ergonomics of `safeTry` when used in class-based designs, eliminating the need for manual binding to preserve context (e.g. `that`). This brings neverthrow in line with other modern Result/Effect libraries that have already adopted this pattern.
