### PR TITLE
docs: fix `Result.map` example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ const linesResult = getLines('1\n2\n3\n4\n')
 
 // this Result now has a Array<number> inside it
 const newResult = linesResult.map(
-  (arr: Array<string>) => arr.map(parseInt)
+  (arr: Array<string>) => arr.map((s) => parseInt(s))
 )
 
 newResult.isOk() // true


### PR DESCRIPTION
Fixes #631.

With the previous example:

```ts
(arr: Array<string>) => arr.map(parseInt)
```

`parseInt` gets the indices as its second parameter for the base.

Providing a callback where we pass the item gets rid of the issue: 

```ts
(arr: Array<string>) => arr.map((s) => parseInt(s))
```

The base now defaults to 10. 

To be even more explicit, we could have also added the second argument to `parseInt` as well, and maybe a comment to explain it:

```ts
// Parse the number as base-10
(arr: Array<string>) => arr.map((s) => parseInt(s, 10))
```

I think the first option is sufficient, but I can make changes to the PR if needed.
